### PR TITLE
fix: challenge format

### DIFF
--- a/Sources/Shared/Stamper.swift
+++ b/Sources/Shared/Stamper.swift
@@ -117,7 +117,11 @@ public class Stamper {
         }
       }
 
-      self.passkeyManager?.assertPasskey(challenge: Data(payload))
+      guard let challenge = payload.compactMap { String(format: "%02x", $0) }.joined().data(using: .utf8) else {
+        continuation.resume(throwing: StampError.assertionFailed)
+      }
+        
+      self.passkeyManager?.assertPasskey(challenge: challenge)
     }
   }
 


### PR DESCRIPTION
The backend expects the challenge in hex format, and SHA256Digest returns only the raw format.

This fixes stamping, which was not working before this.