### PR TITLE
session improvements 

### DIFF
--- a/Sources/TurnkeySwift/Internal/Storage/Keys/PendingKeysStore.swift
+++ b/Sources/TurnkeySwift/Internal/Storage/Keys/PendingKeysStore.swift
@@ -1,41 +1,42 @@
 import Foundation
 
-/// Tracks generated but unused public keys along with their creation timestamps.
+/// Tracks generated but unused public keys along with their expiration timestamps.
 /// This is used to clean up stale key material that was never used to establish a session.
 enum PendingKeysStore {
-  private static let storeKey = Constants.Storage.pendingKeysStoreKey
-  private static let secureAccount = Constants.Storage.secureAccount
-  private static let q = DispatchQueue(label: "pendingKeys", attributes: .concurrent)
-
-  static func add(_ pub: String) throws {
-    try q.sync(flags: .barrier) {
-      var dict = (try? LocalStore.get(storeKey) as [String: Date]?) ?? [:]
-      dict[pub] = Date()
-      try LocalStore.set(dict, for: storeKey)
+    private static let storeKey = Constants.Storage.pendingKeysStoreKey
+    private static let secureAccount = Constants.Storage.secureAccount
+    private static let q = DispatchQueue(label: "pendingKeys", attributes: .concurrent)
+    
+    static func add(_ pub: String, ttlHours: Double = 1) throws {
+        try q.sync(flags: .barrier) {
+            var dict = (try? LocalStore.get(storeKey) as [String: TimeInterval]?) ?? [:]
+            let expiry = Date().addingTimeInterval(ttlHours * 3600).timeIntervalSince1970
+            dict[pub] = expiry
+            try LocalStore.set(dict, for: storeKey)
+        }
     }
-  }
-
-  static func remove(_ pub: String) throws {
-    try q.sync(flags: .barrier) {
-      var dict = (try? LocalStore.get(storeKey) as [String: Date]?) ?? [:]
-      dict.removeValue(forKey: pub)
-      try LocalStore.set(dict, for: storeKey)
+    
+    static func remove(_ pub: String) throws {
+        try q.sync(flags: .barrier) {
+            var dict = (try? LocalStore.get(storeKey) as [String: TimeInterval]?) ?? [:]
+            dict.removeValue(forKey: pub)
+            try LocalStore.set(dict, for: storeKey)
+        }
     }
-  }
-
-  static func all() -> [String: Date] {
-    q.sync { (try? LocalStore.get(storeKey) as [String: Date]?) ?? [:] }
-  }
-
-  static func purge(ttlHours: Double = 24) {
-    let cutoff = Date().addingTimeInterval(-ttlHours * 3600)
-    for (pub, createdAt) in all() where createdAt < cutoff {
-      do {
-        try SecureStore.delete(service: pub, account: secureAccount)
-        try remove(pub)
-      } catch {
-        print("PendingKeysStore purge error for \(pub): \(error)")
-      }
+    
+    static func all() -> [String: TimeInterval] {
+        q.sync { (try? LocalStore.get(storeKey) as [String: TimeInterval]?) ?? [:] }
     }
-  }
+    
+    static func purge() {
+        let now = Date().timeIntervalSince1970
+        for (pub, expiry) in all() where expiry < now {
+            do {
+                try SecureStore.delete(service: pub, account: secureAccount)
+                try remove(pub)
+            } catch {
+                print("PendingKeysStore purge error for \(pub): \(error)")
+            }
+        }
+    }
 }

--- a/Sources/TurnkeySwift/Public/TurnkeyContext+Session.swift
+++ b/Sources/TurnkeySwift/Public/TurnkeyContext+Session.swift
@@ -40,6 +40,8 @@ extension TurnkeyContext {
                 throw TurnkeySwiftError.keyNotFound
             }
             
+            try PendingKeysStore.remove(dto.publicKey)
+            
             if selectedSessionKey == nil {
                 _ = try await setSelectedSession(sessionKey: sessionKey)
             }

--- a/Sources/TurnkeySwift/Public/TurnkeyContext.swift
+++ b/Sources/TurnkeySwift/Public/TurnkeyContext.swift
@@ -40,7 +40,7 @@ public final class TurnkeyContext: NSObject, ObservableObject {
     
     private func postInitSetup() {
         // clean up expired sessions and pending keys
-        PendingKeysStore.purge(ttlHours: 2)
+        PendingKeysStore.purge()
         SessionRegistryStore.purgeExpiredSessions()
         
         // restore session and timers after launch
@@ -53,7 +53,7 @@ public final class TurnkeyContext: NSObject, ObservableObject {
         if let note = Self.foregroundNotification {
             Task.detached {
                 for await _ in NotificationCenter.default.notifications(named: note) {
-                    PendingKeysStore.purge(ttlHours: 1)
+                    PendingKeysStore.purge()
                     SessionRegistryStore.purgeExpiredSessions()
                 }
             }


### PR DESCRIPTION
## Fix long-lived sessions being unexpectedly cleared
A customer reported that sessions were getting cleared after 1–2 hours, even though they should still be valid. Upon investigation, I found that PendingKeysStore was not removing the public key after a session was successfully created.

As a result, the key remained in the pending list and was later purged by our periodic cleanup (which runs every 2 hours). This also removed the key from secure storage, effectively breaking the session even though it hadn't expired.

This PR ensures that the public key is removed from PendingKeysStore immediately after creating a session.




**Note**: These are non-breaking changes