### PR TITLE
add refreshSession + authState

### DIFF
--- a/Examples/swift-demo-wallet/swift-demo-wallet.xcodeproj/xcshareddata/xcschemes/swift-sdk-demo-wallet.xcscheme
+++ b/Examples/swift-demo-wallet/swift-demo-wallet.xcodeproj/xcshareddata/xcschemes/swift-sdk-demo-wallet.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1620"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "8DB100392DD7E3D400885C8F"
+               BuildableName = "swift-sdk-demo-wallet.app"
+               BlueprintName = "swift-sdk-demo-wallet"
+               ReferencedContainer = "container:swift-demo-wallet.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8DB100392DD7E3D400885C8F"
+            BuildableName = "swift-sdk-demo-wallet.app"
+            BlueprintName = "swift-sdk-demo-wallet"
+            ReferencedContainer = "container:swift-demo-wallet.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8DB100392DD7E3D400885C8F"
+            BuildableName = "swift-sdk-demo-wallet.app"
+            BlueprintName = "swift-sdk-demo-wallet"
+            ReferencedContainer = "container:swift-demo-wallet.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Examples/swift-demo-wallet/swift-demo-wallet/Contexts/AuthContext.swift
+++ b/Examples/swift-demo-wallet/swift-demo-wallet/Contexts/AuthContext.swift
@@ -147,7 +147,7 @@ final class AuthContext: ObservableObject {
         }
 
         let result = try JSONDecoder().decode(VerifyOtpResponse.self, from: data)
-        try await turnkey.createSession(jwt: result.token)
+        try await turnkey.createSession(jwt: result.token, refreshedSessionTTLSeconds: Constants.Session.defaultExpirationSeconds)
     }
 
     func signUpWithPasskey(anchor: ASPresentationAnchor) async throws {
@@ -243,7 +243,7 @@ final class AuthContext: ObservableObject {
         }
 
         let result = try JSONDecoder().decode(OAuthLoginResponse.self, from: data)
-        try await turnkey.createSession(jwt: result.token)
+        try await turnkey.createSession(jwt: result.token, refreshedSessionTTLSeconds: Constants.Session.defaultExpirationSeconds)
     }
 
     
@@ -290,7 +290,7 @@ final class AuthContext: ObservableObject {
                 throw AuthError.serverError
             }
 
-            try await turnkey.createSession(jwt: jwt)
+            try await turnkey.createSession(jwt: jwt, refreshedSessionTTLSeconds: Constants.Session.defaultExpirationSeconds)
 
         } catch let error as TurnkeyRequestError {
             print("Turnkey \(error.statusCode ?? 0): \(error.fullMessage)")

--- a/Examples/swift-demo-wallet/swift-demo-wallet/Contexts/AuthContext.swift
+++ b/Examples/swift-demo-wallet/swift-demo-wallet/Contexts/AuthContext.swift
@@ -147,7 +147,7 @@ final class AuthContext: ObservableObject {
         }
 
         let result = try JSONDecoder().decode(VerifyOtpResponse.self, from: data)
-        try await turnkey.createSession(jwt: result.token, refreshedSessionTTLSeconds: Constants.Session.defaultExpirationSeconds)
+        try await turnkey.createSession(jwt: result.token, refreshedSessionTTLSeconds: Constants.Turnkey.sessionDuration)
     }
 
     func signUpWithPasskey(anchor: ASPresentationAnchor) async throws {
@@ -243,7 +243,7 @@ final class AuthContext: ObservableObject {
         }
 
         let result = try JSONDecoder().decode(OAuthLoginResponse.self, from: data)
-        try await turnkey.createSession(jwt: result.token, refreshedSessionTTLSeconds: Constants.Session.defaultExpirationSeconds)
+        try await turnkey.createSession(jwt: result.token, refreshedSessionTTLSeconds: Constants.Turnkey.sessionDuration)
     }
 
     
@@ -290,7 +290,7 @@ final class AuthContext: ObservableObject {
                 throw AuthError.serverError
             }
 
-            try await turnkey.createSession(jwt: jwt, refreshedSessionTTLSeconds: Constants.Session.defaultExpirationSeconds)
+            try await turnkey.createSession(jwt: jwt, refreshedSessionTTLSeconds: Constants.Turnkey.sessionDuration)
 
         } catch let error as TurnkeyRequestError {
             print("Turnkey \(error.statusCode ?? 0): \(error.fullMessage)")

--- a/Examples/swift-demo-wallet/swift-demo-wallet/Contexts/AuthContext.swift
+++ b/Examples/swift-demo-wallet/swift-demo-wallet/Contexts/AuthContext.swift
@@ -293,7 +293,6 @@ final class AuthContext: ObservableObject {
             try await turnkey.createSession(jwt: jwt, refreshedSessionTTLSeconds: Constants.Turnkey.sessionDuration)
 
         } catch let error as TurnkeyRequestError {
-            print("Turnkey \(error.statusCode ?? 0): \(error.fullMessage)")
             throw error
         }
     }

--- a/Sources/TurnkeyHttp/Generated/Client.swift
+++ b/Sources/TurnkeyHttp/Generated/Client.swift
@@ -5652,6 +5652,225 @@ public struct Client: APIProtocol {
       }
     )
   }
+  /// Update User's Email
+  ///
+  /// Update a User's email in an existing Organization
+  ///
+  /// - Remark: HTTP `POST /public/v1/submit/update_user_email`.
+  /// - Remark: Generated from `#/paths//public/v1/submit/update_user_email/post(UpdateUserEmail)`.
+  public func UpdateUserEmail(_ input: Operations.UpdateUserEmail.Input) async throws
+    -> Operations.UpdateUserEmail.Output
+  {
+    try await client.send(
+      input: input,
+      forOperation: Operations.UpdateUserEmail.id,
+      serializer: { input in
+        let path = try converter.renderedPath(
+          template: "/public/v1/submit/update_user_email",
+          parameters: []
+        )
+        var request: HTTPTypes.HTTPRequest = .init(
+          soar_path: path,
+          method: .post
+        )
+        suppressMutabilityWarning(&request)
+        converter.setAcceptHeader(
+          in: &request.headerFields,
+          contentTypes: input.headers.accept
+        )
+        let body: OpenAPIRuntime.HTTPBody?
+        switch input.body {
+        case let .json(value):
+          body = try converter.setRequiredRequestBodyAsJSON(
+            value,
+            headerFields: &request.headerFields,
+            contentType: "application/json; charset=utf-8"
+          )
+        }
+        return (request, body)
+      },
+      deserializer: { response, responseBody in
+        switch response.status.code {
+        case 200:
+          let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
+          let body: Operations.UpdateUserEmail.Output.Ok.Body
+          let chosenContentType = try converter.bestContentType(
+            received: contentType,
+            options: [
+              "application/json"
+            ]
+          )
+          switch chosenContentType {
+          case "application/json":
+            body = try await converter.getResponseBodyAsJSON(
+              Components.Schemas.ActivityResponse.self,
+              from: responseBody,
+              transforming: { value in
+                .json(value)
+              }
+            )
+          default:
+            preconditionFailure("bestContentType chose an invalid content type.")
+          }
+          return .ok(.init(body: body))
+        default:
+          return .undocumented(
+            statusCode: response.status.code,
+            .init(
+              headerFields: response.headerFields,
+              body: responseBody
+            )
+          )
+        }
+      }
+    )
+  }
+  /// Update User's Name
+  ///
+  /// Update a User's name in an existing Organization
+  ///
+  /// - Remark: HTTP `POST /public/v1/submit/update_user_name`.
+  /// - Remark: Generated from `#/paths//public/v1/submit/update_user_name/post(UpdateUserName)`.
+  public func UpdateUserName(_ input: Operations.UpdateUserName.Input) async throws
+    -> Operations.UpdateUserName.Output
+  {
+    try await client.send(
+      input: input,
+      forOperation: Operations.UpdateUserName.id,
+      serializer: { input in
+        let path = try converter.renderedPath(
+          template: "/public/v1/submit/update_user_name",
+          parameters: []
+        )
+        var request: HTTPTypes.HTTPRequest = .init(
+          soar_path: path,
+          method: .post
+        )
+        suppressMutabilityWarning(&request)
+        converter.setAcceptHeader(
+          in: &request.headerFields,
+          contentTypes: input.headers.accept
+        )
+        let body: OpenAPIRuntime.HTTPBody?
+        switch input.body {
+        case let .json(value):
+          body = try converter.setRequiredRequestBodyAsJSON(
+            value,
+            headerFields: &request.headerFields,
+            contentType: "application/json; charset=utf-8"
+          )
+        }
+        return (request, body)
+      },
+      deserializer: { response, responseBody in
+        switch response.status.code {
+        case 200:
+          let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
+          let body: Operations.UpdateUserName.Output.Ok.Body
+          let chosenContentType = try converter.bestContentType(
+            received: contentType,
+            options: [
+              "application/json"
+            ]
+          )
+          switch chosenContentType {
+          case "application/json":
+            body = try await converter.getResponseBodyAsJSON(
+              Components.Schemas.ActivityResponse.self,
+              from: responseBody,
+              transforming: { value in
+                .json(value)
+              }
+            )
+          default:
+            preconditionFailure("bestContentType chose an invalid content type.")
+          }
+          return .ok(.init(body: body))
+        default:
+          return .undocumented(
+            statusCode: response.status.code,
+            .init(
+              headerFields: response.headerFields,
+              body: responseBody
+            )
+          )
+        }
+      }
+    )
+  }
+  /// Update User's Phone Number
+  ///
+  /// Update a User's phone number in an existing Organization
+  ///
+  /// - Remark: HTTP `POST /public/v1/submit/update_user_phone_number`.
+  /// - Remark: Generated from `#/paths//public/v1/submit/update_user_phone_number/post(UpdateUserPhoneNumber)`.
+  public func UpdateUserPhoneNumber(_ input: Operations.UpdateUserPhoneNumber.Input) async throws
+    -> Operations.UpdateUserPhoneNumber.Output
+  {
+    try await client.send(
+      input: input,
+      forOperation: Operations.UpdateUserPhoneNumber.id,
+      serializer: { input in
+        let path = try converter.renderedPath(
+          template: "/public/v1/submit/update_user_phone_number",
+          parameters: []
+        )
+        var request: HTTPTypes.HTTPRequest = .init(
+          soar_path: path,
+          method: .post
+        )
+        suppressMutabilityWarning(&request)
+        converter.setAcceptHeader(
+          in: &request.headerFields,
+          contentTypes: input.headers.accept
+        )
+        let body: OpenAPIRuntime.HTTPBody?
+        switch input.body {
+        case let .json(value):
+          body = try converter.setRequiredRequestBodyAsJSON(
+            value,
+            headerFields: &request.headerFields,
+            contentType: "application/json; charset=utf-8"
+          )
+        }
+        return (request, body)
+      },
+      deserializer: { response, responseBody in
+        switch response.status.code {
+        case 200:
+          let contentType = converter.extractContentTypeIfPresent(in: response.headerFields)
+          let body: Operations.UpdateUserPhoneNumber.Output.Ok.Body
+          let chosenContentType = try converter.bestContentType(
+            received: contentType,
+            options: [
+              "application/json"
+            ]
+          )
+          switch chosenContentType {
+          case "application/json":
+            body = try await converter.getResponseBodyAsJSON(
+              Components.Schemas.ActivityResponse.self,
+              from: responseBody,
+              transforming: { value in
+                .json(value)
+              }
+            )
+          default:
+            preconditionFailure("bestContentType chose an invalid content type.")
+          }
+          return .ok(.init(body: body))
+        default:
+          return .undocumented(
+            statusCode: response.status.code,
+            .init(
+              headerFields: response.headerFields,
+              body: responseBody
+            )
+          )
+        }
+      }
+    )
+  }
   /// Update User Tag
   ///
   /// Update human-readable name or associated users. Note that this activity is atomic: all of the updates will succeed at once, or all of them will fail.

--- a/Sources/TurnkeyHttp/Generated/Types.swift
+++ b/Sources/TurnkeyHttp/Generated/Types.swift
@@ -612,6 +612,30 @@ public protocol APIProtocol: Sendable {
   /// - Remark: HTTP `POST /public/v1/submit/update_user`.
   /// - Remark: Generated from `#/paths//public/v1/submit/update_user/post(UpdateUser)`.
   func UpdateUser(_ input: Operations.UpdateUser.Input) async throws -> Operations.UpdateUser.Output
+  /// Update User's Email
+  ///
+  /// Update a User's email in an existing Organization
+  ///
+  /// - Remark: HTTP `POST /public/v1/submit/update_user_email`.
+  /// - Remark: Generated from `#/paths//public/v1/submit/update_user_email/post(UpdateUserEmail)`.
+  func UpdateUserEmail(_ input: Operations.UpdateUserEmail.Input) async throws
+    -> Operations.UpdateUserEmail.Output
+  /// Update User's Name
+  ///
+  /// Update a User's name in an existing Organization
+  ///
+  /// - Remark: HTTP `POST /public/v1/submit/update_user_name`.
+  /// - Remark: Generated from `#/paths//public/v1/submit/update_user_name/post(UpdateUserName)`.
+  func UpdateUserName(_ input: Operations.UpdateUserName.Input) async throws
+    -> Operations.UpdateUserName.Output
+  /// Update User's Phone Number
+  ///
+  /// Update a User's phone number in an existing Organization
+  ///
+  /// - Remark: HTTP `POST /public/v1/submit/update_user_phone_number`.
+  /// - Remark: Generated from `#/paths//public/v1/submit/update_user_phone_number/post(UpdateUserPhoneNumber)`.
+  func UpdateUserPhoneNumber(_ input: Operations.UpdateUserPhoneNumber.Input) async throws
+    -> Operations.UpdateUserPhoneNumber.Output
   /// Update User Tag
   ///
   /// Update human-readable name or associated users. Note that this activity is atomic: all of the updates will succeed at once, or all of them will fail.
@@ -1871,6 +1895,54 @@ extension APIProtocol {
         body: body
       ))
   }
+  /// Update User's Email
+  ///
+  /// Update a User's email in an existing Organization
+  ///
+  /// - Remark: HTTP `POST /public/v1/submit/update_user_email`.
+  /// - Remark: Generated from `#/paths//public/v1/submit/update_user_email/post(UpdateUserEmail)`.
+  public func UpdateUserEmail(
+    headers: Operations.UpdateUserEmail.Input.Headers = .init(),
+    body: Operations.UpdateUserEmail.Input.Body
+  ) async throws -> Operations.UpdateUserEmail.Output {
+    try await UpdateUserEmail(
+      Operations.UpdateUserEmail.Input(
+        headers: headers,
+        body: body
+      ))
+  }
+  /// Update User's Name
+  ///
+  /// Update a User's name in an existing Organization
+  ///
+  /// - Remark: HTTP `POST /public/v1/submit/update_user_name`.
+  /// - Remark: Generated from `#/paths//public/v1/submit/update_user_name/post(UpdateUserName)`.
+  public func UpdateUserName(
+    headers: Operations.UpdateUserName.Input.Headers = .init(),
+    body: Operations.UpdateUserName.Input.Body
+  ) async throws -> Operations.UpdateUserName.Output {
+    try await UpdateUserName(
+      Operations.UpdateUserName.Input(
+        headers: headers,
+        body: body
+      ))
+  }
+  /// Update User's Phone Number
+  ///
+  /// Update a User's phone number in an existing Organization
+  ///
+  /// - Remark: HTTP `POST /public/v1/submit/update_user_phone_number`.
+  /// - Remark: Generated from `#/paths//public/v1/submit/update_user_phone_number/post(UpdateUserPhoneNumber)`.
+  public func UpdateUserPhoneNumber(
+    headers: Operations.UpdateUserPhoneNumber.Input.Headers = .init(),
+    body: Operations.UpdateUserPhoneNumber.Input.Body
+  ) async throws -> Operations.UpdateUserPhoneNumber.Output {
+    try await UpdateUserPhoneNumber(
+      Operations.UpdateUserPhoneNumber.Input(
+        headers: headers,
+        body: body
+      ))
+  }
   /// Update User Tag
   ///
   /// Update human-readable name or associated users. Note that this activity is atomic: all of the updates will succeed at once, or all of them will fail.
@@ -2288,6 +2360,9 @@ public enum Components {
       case ACTIVITY_TYPE_OTP_LOGIN = "ACTIVITY_TYPE_OTP_LOGIN"
       case ACTIVITY_TYPE_STAMP_LOGIN = "ACTIVITY_TYPE_STAMP_LOGIN"
       case ACTIVITY_TYPE_OAUTH_LOGIN = "ACTIVITY_TYPE_OAUTH_LOGIN"
+      case ACTIVITY_TYPE_UPDATE_USER_NAME = "ACTIVITY_TYPE_UPDATE_USER_NAME"
+      case ACTIVITY_TYPE_UPDATE_USER_EMAIL = "ACTIVITY_TYPE_UPDATE_USER_EMAIL"
+      case ACTIVITY_TYPE_UPDATE_USER_PHONE_NUMBER = "ACTIVITY_TYPE_UPDATE_USER_PHONE_NUMBER"
     }
     /// - Remark: Generated from `#/components/schemas/AddressFormat`.
     @frozen public enum AddressFormat: String, Codable, Hashable, Sendable, CaseIterable {
@@ -2325,6 +2400,7 @@ public enum Components {
       case ADDRESS_FORMAT_DOGE_TESTNET = "ADDRESS_FORMAT_DOGE_TESTNET"
       case ADDRESS_FORMAT_TON_V3R2 = "ADDRESS_FORMAT_TON_V3R2"
       case ADDRESS_FORMAT_TON_V4R2 = "ADDRESS_FORMAT_TON_V4R2"
+      case ADDRESS_FORMAT_TON_V5R1 = "ADDRESS_FORMAT_TON_V5R1"
       case ADDRESS_FORMAT_XRP = "ADDRESS_FORMAT_XRP"
     }
     /// - Remark: Generated from `#/components/schemas/Any`.
@@ -5606,12 +5682,12 @@ public enum Components {
       /// The payment method that the customer wants to remove.
       ///
       /// - Remark: Generated from `#/components/schemas/DeletePaymentMethodIntent/paymentMethodId`.
-      public var paymentMethodId: Swift.String
+      public var paymentMethodId: Swift.String?
       /// Creates a new `DeletePaymentMethodIntent`.
       ///
       /// - Parameters:
       ///   - paymentMethodId: The payment method that the customer wants to remove.
-      public init(paymentMethodId: Swift.String) {
+      public init(paymentMethodId: Swift.String? = nil) {
         self.paymentMethodId = paymentMethodId
       }
       public enum CodingKeys: String, CodingKey {
@@ -8850,6 +8926,12 @@ public enum Components {
       public var stampLoginIntent: Components.Schemas.StampLoginIntent?
       /// - Remark: Generated from `#/components/schemas/Intent/oauthLoginIntent`.
       public var oauthLoginIntent: Components.Schemas.OauthLoginIntent?
+      /// - Remark: Generated from `#/components/schemas/Intent/updateUserNameIntent`.
+      public var updateUserNameIntent: Components.Schemas.UpdateUserNameIntent?
+      /// - Remark: Generated from `#/components/schemas/Intent/updateUserEmailIntent`.
+      public var updateUserEmailIntent: Components.Schemas.UpdateUserEmailIntent?
+      /// - Remark: Generated from `#/components/schemas/Intent/updateUserPhoneNumberIntent`.
+      public var updateUserPhoneNumberIntent: Components.Schemas.UpdateUserPhoneNumberIntent?
       /// Creates a new `Intent`.
       ///
       /// - Parameters:
@@ -8941,6 +9023,9 @@ public enum Components {
       ///   - otpLoginIntent:
       ///   - stampLoginIntent:
       ///   - oauthLoginIntent:
+      ///   - updateUserNameIntent:
+      ///   - updateUserEmailIntent:
+      ///   - updateUserPhoneNumberIntent:
       public init(
         createOrganizationIntent: Components.Schemas.CreateOrganizationIntent? = nil,
         createAuthenticatorsIntent: Components.Schemas.CreateAuthenticatorsIntent? = nil,
@@ -9029,7 +9114,10 @@ public enum Components {
         verifyOtpIntent: Components.Schemas.VerifyOtpIntent? = nil,
         otpLoginIntent: Components.Schemas.OtpLoginIntent? = nil,
         stampLoginIntent: Components.Schemas.StampLoginIntent? = nil,
-        oauthLoginIntent: Components.Schemas.OauthLoginIntent? = nil
+        oauthLoginIntent: Components.Schemas.OauthLoginIntent? = nil,
+        updateUserNameIntent: Components.Schemas.UpdateUserNameIntent? = nil,
+        updateUserEmailIntent: Components.Schemas.UpdateUserEmailIntent? = nil,
+        updateUserPhoneNumberIntent: Components.Schemas.UpdateUserPhoneNumberIntent? = nil
       ) {
         self.createOrganizationIntent = createOrganizationIntent
         self.createAuthenticatorsIntent = createAuthenticatorsIntent
@@ -9119,6 +9207,9 @@ public enum Components {
         self.otpLoginIntent = otpLoginIntent
         self.stampLoginIntent = stampLoginIntent
         self.oauthLoginIntent = oauthLoginIntent
+        self.updateUserNameIntent = updateUserNameIntent
+        self.updateUserEmailIntent = updateUserEmailIntent
+        self.updateUserPhoneNumberIntent = updateUserPhoneNumberIntent
       }
       public enum CodingKeys: String, CodingKey {
         case createOrganizationIntent
@@ -9209,6 +9300,9 @@ public enum Components {
         case otpLoginIntent
         case stampLoginIntent
         case oauthLoginIntent
+        case updateUserNameIntent
+        case updateUserEmailIntent
+        case updateUserPhoneNumberIntent
       }
     }
     /// - Remark: Generated from `#/components/schemas/InvitationParams`.
@@ -9983,11 +10077,11 @@ public enum Components {
       /// A consensus expression that evalutes to true or false.
       ///
       /// - Remark: Generated from `#/components/schemas/Policy/consensus`.
-      public var consensus: Swift.String
+      public var consensus: Swift.String?
       /// A condition expression that evalutes to true or false.
       ///
       /// - Remark: Generated from `#/components/schemas/Policy/condition`.
-      public var condition: Swift.String
+      public var condition: Swift.String?
       /// Creates a new `Policy`.
       ///
       /// - Parameters:
@@ -10006,8 +10100,8 @@ public enum Components {
         createdAt: Components.Schemas.external_period_data_period_v1_period_Timestamp,
         updatedAt: Components.Schemas.external_period_data_period_v1_period_Timestamp,
         notes: Swift.String,
-        consensus: Swift.String,
-        condition: Swift.String
+        consensus: Swift.String? = nil,
+        condition: Swift.String? = nil
       ) {
         self.policyId = policyId
         self.policyName = policyName
@@ -10607,6 +10701,12 @@ public enum Components {
       public var stampLoginResult: Components.Schemas.StampLoginResult?
       /// - Remark: Generated from `#/components/schemas/Result/oauthLoginResult`.
       public var oauthLoginResult: Components.Schemas.OauthLoginResult?
+      /// - Remark: Generated from `#/components/schemas/Result/updateUserNameResult`.
+      public var updateUserNameResult: Components.Schemas.UpdateUserNameResult?
+      /// - Remark: Generated from `#/components/schemas/Result/updateUserEmailResult`.
+      public var updateUserEmailResult: Components.Schemas.UpdateUserEmailResult?
+      /// - Remark: Generated from `#/components/schemas/Result/updateUserPhoneNumberResult`.
+      public var updateUserPhoneNumberResult: Components.Schemas.UpdateUserPhoneNumberResult?
       /// Creates a new `Result`.
       ///
       /// - Parameters:
@@ -10683,6 +10783,9 @@ public enum Components {
       ///   - otpLoginResult:
       ///   - stampLoginResult:
       ///   - oauthLoginResult:
+      ///   - updateUserNameResult:
+      ///   - updateUserEmailResult:
+      ///   - updateUserPhoneNumberResult:
       public init(
         createOrganizationResult: Components.Schemas.CreateOrganizationResult? = nil,
         createAuthenticatorsResult: Components.Schemas.CreateAuthenticatorsResult? = nil,
@@ -10756,7 +10859,10 @@ public enum Components {
         verifyOtpResult: Components.Schemas.VerifyOtpResult? = nil,
         otpLoginResult: Components.Schemas.OtpLoginResult? = nil,
         stampLoginResult: Components.Schemas.StampLoginResult? = nil,
-        oauthLoginResult: Components.Schemas.OauthLoginResult? = nil
+        oauthLoginResult: Components.Schemas.OauthLoginResult? = nil,
+        updateUserNameResult: Components.Schemas.UpdateUserNameResult? = nil,
+        updateUserEmailResult: Components.Schemas.UpdateUserEmailResult? = nil,
+        updateUserPhoneNumberResult: Components.Schemas.UpdateUserPhoneNumberResult? = nil
       ) {
         self.createOrganizationResult = createOrganizationResult
         self.createAuthenticatorsResult = createAuthenticatorsResult
@@ -10831,6 +10937,9 @@ public enum Components {
         self.otpLoginResult = otpLoginResult
         self.stampLoginResult = stampLoginResult
         self.oauthLoginResult = oauthLoginResult
+        self.updateUserNameResult = updateUserNameResult
+        self.updateUserEmailResult = updateUserEmailResult
+        self.updateUserPhoneNumberResult = updateUserPhoneNumberResult
       }
       public enum CodingKeys: String, CodingKey {
         case createOrganizationResult
@@ -10906,6 +11015,9 @@ public enum Components {
         case otpLoginResult
         case stampLoginResult
         case oauthLoginResult
+        case updateUserNameResult
+        case updateUserEmailResult
+        case updateUserPhoneNumberResult
       }
     }
     /// - Remark: Generated from `#/components/schemas/RootUserParams`.
@@ -11177,7 +11289,7 @@ public enum Components {
       /// Optional value for the feature. Will override existing values if feature is already set.
       ///
       /// - Remark: Generated from `#/components/schemas/SetOrganizationFeatureIntent/value`.
-      public var value: Swift.String
+      public var value: Swift.String?
       /// Creates a new `SetOrganizationFeatureIntent`.
       ///
       /// - Parameters:
@@ -11185,7 +11297,7 @@ public enum Components {
       ///   - value: Optional value for the feature. Will override existing values if feature is already set.
       public init(
         name: Components.Schemas.FeatureName,
-        value: Swift.String
+        value: Swift.String? = nil
       ) {
         self.name = name
         self.value = value
@@ -12327,6 +12439,101 @@ public enum Components {
     }
     /// - Remark: Generated from `#/components/schemas/UpdateRootQuorumResult`.
     public typealias UpdateRootQuorumResult = OpenAPIRuntime.OpenAPIObjectContainer
+    /// - Remark: Generated from `#/components/schemas/UpdateUserEmailIntent`.
+    public struct UpdateUserEmailIntent: Codable, Hashable, Sendable {
+      /// Unique identifier for a given User.
+      ///
+      /// - Remark: Generated from `#/components/schemas/UpdateUserEmailIntent/userId`.
+      public var userId: Swift.String
+      /// The user's email address. Setting this to an empty string will remove the user's email.
+      ///
+      /// - Remark: Generated from `#/components/schemas/UpdateUserEmailIntent/userEmail`.
+      public var userEmail: Swift.String
+      /// Signed JWT containing a unique id, expiry, verification type, contact
+      ///
+      /// - Remark: Generated from `#/components/schemas/UpdateUserEmailIntent/verificationToken`.
+      public var verificationToken: Swift.String?
+      /// Creates a new `UpdateUserEmailIntent`.
+      ///
+      /// - Parameters:
+      ///   - userId: Unique identifier for a given User.
+      ///   - userEmail: The user's email address. Setting this to an empty string will remove the user's email.
+      ///   - verificationToken: Signed JWT containing a unique id, expiry, verification type, contact
+      public init(
+        userId: Swift.String,
+        userEmail: Swift.String,
+        verificationToken: Swift.String? = nil
+      ) {
+        self.userId = userId
+        self.userEmail = userEmail
+        self.verificationToken = verificationToken
+      }
+      public enum CodingKeys: String, CodingKey {
+        case userId
+        case userEmail
+        case verificationToken
+      }
+    }
+    /// - Remark: Generated from `#/components/schemas/UpdateUserEmailRequest`.
+    public struct UpdateUserEmailRequest: Codable, Hashable, Sendable {
+      /// - Remark: Generated from `#/components/schemas/UpdateUserEmailRequest/type`.
+      @frozen public enum _typePayload: String, Codable, Hashable, Sendable, CaseIterable {
+        case ACTIVITY_TYPE_UPDATE_USER_EMAIL = "ACTIVITY_TYPE_UPDATE_USER_EMAIL"
+      }
+      /// - Remark: Generated from `#/components/schemas/UpdateUserEmailRequest/type`.
+      public var _type: Components.Schemas.UpdateUserEmailRequest._typePayload
+      /// Timestamp (in milliseconds) of the request, used to verify liveness of user requests.
+      ///
+      /// - Remark: Generated from `#/components/schemas/UpdateUserEmailRequest/timestampMs`.
+      public var timestampMs: Swift.String
+      /// Unique identifier for a given Organization.
+      ///
+      /// - Remark: Generated from `#/components/schemas/UpdateUserEmailRequest/organizationId`.
+      public var organizationId: Swift.String
+      /// - Remark: Generated from `#/components/schemas/UpdateUserEmailRequest/parameters`.
+      public var parameters: Components.Schemas.UpdateUserEmailIntent
+      /// Creates a new `UpdateUserEmailRequest`.
+      ///
+      /// - Parameters:
+      ///   - _type:
+      ///   - timestampMs: Timestamp (in milliseconds) of the request, used to verify liveness of user requests.
+      ///   - organizationId: Unique identifier for a given Organization.
+      ///   - parameters:
+      public init(
+        _type: Components.Schemas.UpdateUserEmailRequest._typePayload,
+        timestampMs: Swift.String,
+        organizationId: Swift.String,
+        parameters: Components.Schemas.UpdateUserEmailIntent
+      ) {
+        self._type = _type
+        self.timestampMs = timestampMs
+        self.organizationId = organizationId
+        self.parameters = parameters
+      }
+      public enum CodingKeys: String, CodingKey {
+        case _type = "type"
+        case timestampMs
+        case organizationId
+        case parameters
+      }
+    }
+    /// - Remark: Generated from `#/components/schemas/UpdateUserEmailResult`.
+    public struct UpdateUserEmailResult: Codable, Hashable, Sendable {
+      /// Unique identifier of the User whose email was updated.
+      ///
+      /// - Remark: Generated from `#/components/schemas/UpdateUserEmailResult/userId`.
+      public var userId: Swift.String
+      /// Creates a new `UpdateUserEmailResult`.
+      ///
+      /// - Parameters:
+      ///   - userId: Unique identifier of the User whose email was updated.
+      public init(userId: Swift.String) {
+        self.userId = userId
+      }
+      public enum CodingKeys: String, CodingKey {
+        case userId
+      }
+    }
     /// - Remark: Generated from `#/components/schemas/UpdateUserIntent`.
     public struct UpdateUserIntent: Codable, Hashable, Sendable {
       /// Unique identifier for a given User.
@@ -12376,6 +12583,188 @@ public enum Components {
         case userEmail
         case userTagIds
         case userPhoneNumber
+      }
+    }
+    /// - Remark: Generated from `#/components/schemas/UpdateUserNameIntent`.
+    public struct UpdateUserNameIntent: Codable, Hashable, Sendable {
+      /// Unique identifier for a given User.
+      ///
+      /// - Remark: Generated from `#/components/schemas/UpdateUserNameIntent/userId`.
+      public var userId: Swift.String
+      /// Human-readable name for a User.
+      ///
+      /// - Remark: Generated from `#/components/schemas/UpdateUserNameIntent/userName`.
+      public var userName: Swift.String
+      /// Creates a new `UpdateUserNameIntent`.
+      ///
+      /// - Parameters:
+      ///   - userId: Unique identifier for a given User.
+      ///   - userName: Human-readable name for a User.
+      public init(
+        userId: Swift.String,
+        userName: Swift.String
+      ) {
+        self.userId = userId
+        self.userName = userName
+      }
+      public enum CodingKeys: String, CodingKey {
+        case userId
+        case userName
+      }
+    }
+    /// - Remark: Generated from `#/components/schemas/UpdateUserNameRequest`.
+    public struct UpdateUserNameRequest: Codable, Hashable, Sendable {
+      /// - Remark: Generated from `#/components/schemas/UpdateUserNameRequest/type`.
+      @frozen public enum _typePayload: String, Codable, Hashable, Sendable, CaseIterable {
+        case ACTIVITY_TYPE_UPDATE_USER_NAME = "ACTIVITY_TYPE_UPDATE_USER_NAME"
+      }
+      /// - Remark: Generated from `#/components/schemas/UpdateUserNameRequest/type`.
+      public var _type: Components.Schemas.UpdateUserNameRequest._typePayload
+      /// Timestamp (in milliseconds) of the request, used to verify liveness of user requests.
+      ///
+      /// - Remark: Generated from `#/components/schemas/UpdateUserNameRequest/timestampMs`.
+      public var timestampMs: Swift.String
+      /// Unique identifier for a given Organization.
+      ///
+      /// - Remark: Generated from `#/components/schemas/UpdateUserNameRequest/organizationId`.
+      public var organizationId: Swift.String
+      /// - Remark: Generated from `#/components/schemas/UpdateUserNameRequest/parameters`.
+      public var parameters: Components.Schemas.UpdateUserNameIntent
+      /// Creates a new `UpdateUserNameRequest`.
+      ///
+      /// - Parameters:
+      ///   - _type:
+      ///   - timestampMs: Timestamp (in milliseconds) of the request, used to verify liveness of user requests.
+      ///   - organizationId: Unique identifier for a given Organization.
+      ///   - parameters:
+      public init(
+        _type: Components.Schemas.UpdateUserNameRequest._typePayload,
+        timestampMs: Swift.String,
+        organizationId: Swift.String,
+        parameters: Components.Schemas.UpdateUserNameIntent
+      ) {
+        self._type = _type
+        self.timestampMs = timestampMs
+        self.organizationId = organizationId
+        self.parameters = parameters
+      }
+      public enum CodingKeys: String, CodingKey {
+        case _type = "type"
+        case timestampMs
+        case organizationId
+        case parameters
+      }
+    }
+    /// - Remark: Generated from `#/components/schemas/UpdateUserNameResult`.
+    public struct UpdateUserNameResult: Codable, Hashable, Sendable {
+      /// Unique identifier of the User whose name was updated.
+      ///
+      /// - Remark: Generated from `#/components/schemas/UpdateUserNameResult/userId`.
+      public var userId: Swift.String
+      /// Creates a new `UpdateUserNameResult`.
+      ///
+      /// - Parameters:
+      ///   - userId: Unique identifier of the User whose name was updated.
+      public init(userId: Swift.String) {
+        self.userId = userId
+      }
+      public enum CodingKeys: String, CodingKey {
+        case userId
+      }
+    }
+    /// - Remark: Generated from `#/components/schemas/UpdateUserPhoneNumberIntent`.
+    public struct UpdateUserPhoneNumberIntent: Codable, Hashable, Sendable {
+      /// Unique identifier for a given User.
+      ///
+      /// - Remark: Generated from `#/components/schemas/UpdateUserPhoneNumberIntent/userId`.
+      public var userId: Swift.String
+      /// The user's phone number in E.164 format e.g. +13214567890. Setting this to an empty string will remove the user's phone number.
+      ///
+      /// - Remark: Generated from `#/components/schemas/UpdateUserPhoneNumberIntent/userPhoneNumber`.
+      public var userPhoneNumber: Swift.String
+      /// Signed JWT containing a unique id, expiry, verification type, contact
+      ///
+      /// - Remark: Generated from `#/components/schemas/UpdateUserPhoneNumberIntent/verificationToken`.
+      public var verificationToken: Swift.String?
+      /// Creates a new `UpdateUserPhoneNumberIntent`.
+      ///
+      /// - Parameters:
+      ///   - userId: Unique identifier for a given User.
+      ///   - userPhoneNumber: The user's phone number in E.164 format e.g. +13214567890. Setting this to an empty string will remove the user's phone number.
+      ///   - verificationToken: Signed JWT containing a unique id, expiry, verification type, contact
+      public init(
+        userId: Swift.String,
+        userPhoneNumber: Swift.String,
+        verificationToken: Swift.String? = nil
+      ) {
+        self.userId = userId
+        self.userPhoneNumber = userPhoneNumber
+        self.verificationToken = verificationToken
+      }
+      public enum CodingKeys: String, CodingKey {
+        case userId
+        case userPhoneNumber
+        case verificationToken
+      }
+    }
+    /// - Remark: Generated from `#/components/schemas/UpdateUserPhoneNumberRequest`.
+    public struct UpdateUserPhoneNumberRequest: Codable, Hashable, Sendable {
+      /// - Remark: Generated from `#/components/schemas/UpdateUserPhoneNumberRequest/type`.
+      @frozen public enum _typePayload: String, Codable, Hashable, Sendable, CaseIterable {
+        case ACTIVITY_TYPE_UPDATE_USER_PHONE_NUMBER = "ACTIVITY_TYPE_UPDATE_USER_PHONE_NUMBER"
+      }
+      /// - Remark: Generated from `#/components/schemas/UpdateUserPhoneNumberRequest/type`.
+      public var _type: Components.Schemas.UpdateUserPhoneNumberRequest._typePayload
+      /// Timestamp (in milliseconds) of the request, used to verify liveness of user requests.
+      ///
+      /// - Remark: Generated from `#/components/schemas/UpdateUserPhoneNumberRequest/timestampMs`.
+      public var timestampMs: Swift.String
+      /// Unique identifier for a given Organization.
+      ///
+      /// - Remark: Generated from `#/components/schemas/UpdateUserPhoneNumberRequest/organizationId`.
+      public var organizationId: Swift.String
+      /// - Remark: Generated from `#/components/schemas/UpdateUserPhoneNumberRequest/parameters`.
+      public var parameters: Components.Schemas.UpdateUserPhoneNumberIntent
+      /// Creates a new `UpdateUserPhoneNumberRequest`.
+      ///
+      /// - Parameters:
+      ///   - _type:
+      ///   - timestampMs: Timestamp (in milliseconds) of the request, used to verify liveness of user requests.
+      ///   - organizationId: Unique identifier for a given Organization.
+      ///   - parameters:
+      public init(
+        _type: Components.Schemas.UpdateUserPhoneNumberRequest._typePayload,
+        timestampMs: Swift.String,
+        organizationId: Swift.String,
+        parameters: Components.Schemas.UpdateUserPhoneNumberIntent
+      ) {
+        self._type = _type
+        self.timestampMs = timestampMs
+        self.organizationId = organizationId
+        self.parameters = parameters
+      }
+      public enum CodingKeys: String, CodingKey {
+        case _type = "type"
+        case timestampMs
+        case organizationId
+        case parameters
+      }
+    }
+    /// - Remark: Generated from `#/components/schemas/UpdateUserPhoneNumberResult`.
+    public struct UpdateUserPhoneNumberResult: Codable, Hashable, Sendable {
+      /// Unique identifier of the User whose phone number was updated.
+      ///
+      /// - Remark: Generated from `#/components/schemas/UpdateUserPhoneNumberResult/userId`.
+      public var userId: Swift.String
+      /// Creates a new `UpdateUserPhoneNumberResult`.
+      ///
+      /// - Parameters:
+      ///   - userId: Unique identifier of the User whose phone number was updated.
+      public init(userId: Swift.String) {
+        self.userId = userId
+      }
+      public enum CodingKeys: String, CodingKey {
+        case userId
       }
     }
     /// - Remark: Generated from `#/components/schemas/UpdateUserRequest`.
@@ -12970,14 +13359,14 @@ public enum Components {
     }
     /// - Remark: Generated from `#/components/schemas/VerifyOtpResult`.
     public struct VerifyOtpResult: Codable, Hashable, Sendable {
-      /// Signed JWT containing a unique id, expiry, verification type, contact
+      /// Signed JWT containing a unique id, expiry, verification type, contact. Verification status of a user is updated when the token is consumed (in OTP_LOGIN requests)
       ///
       /// - Remark: Generated from `#/components/schemas/VerifyOtpResult/verificationToken`.
       public var verificationToken: Swift.String
       /// Creates a new `VerifyOtpResult`.
       ///
       /// - Parameters:
-      ///   - verificationToken: Signed JWT containing a unique id, expiry, verification type, contact
+      ///   - verificationToken: Signed JWT containing a unique id, expiry, verification type, contact. Verification status of a user is updated when the token is consumed (in OTP_LOGIN requests)
       public init(verificationToken: Swift.String) {
         self.verificationToken = verificationToken
       }
@@ -23373,6 +23762,392 @@ public enum Operations {
       /// - Throws: An error if `self` is not `.ok`.
       /// - SeeAlso: `.ok`.
       public var ok: Operations.UpdateUser.Output.Ok {
+        get throws {
+          switch self {
+          case let .ok(response):
+            return response
+          default:
+            try throwUnexpectedResponseStatus(
+              expectedStatus: "ok",
+              response: self
+            )
+          }
+        }
+      }
+      /// Undocumented response.
+      ///
+      /// A response with a code that is not documented in the OpenAPI document.
+      case undocumented(statusCode: Swift.Int, OpenAPIRuntime.UndocumentedPayload)
+    }
+    @frozen public enum AcceptableContentType: AcceptableProtocol {
+      case json
+      case other(Swift.String)
+      public init?(rawValue: Swift.String) {
+        switch rawValue.lowercased() {
+        case "application/json":
+          self = .json
+        default:
+          self = .other(rawValue)
+        }
+      }
+      public var rawValue: Swift.String {
+        switch self {
+        case let .other(string):
+          return string
+        case .json:
+          return "application/json"
+        }
+      }
+      public static var allCases: [Self] {
+        [
+          .json
+        ]
+      }
+    }
+  }
+  /// Update User's Email
+  ///
+  /// Update a User's email in an existing Organization
+  ///
+  /// - Remark: HTTP `POST /public/v1/submit/update_user_email`.
+  /// - Remark: Generated from `#/paths//public/v1/submit/update_user_email/post(UpdateUserEmail)`.
+  public enum UpdateUserEmail {
+    public static let id: Swift.String = "UpdateUserEmail"
+    public struct Input: Sendable, Hashable {
+      /// - Remark: Generated from `#/paths/public/v1/submit/update_user_email/POST/header`.
+      public struct Headers: Sendable, Hashable {
+        public var accept:
+          [OpenAPIRuntime.AcceptHeaderContentType<Operations.UpdateUserEmail.AcceptableContentType>]
+        /// Creates a new `Headers`.
+        ///
+        /// - Parameters:
+        ///   - accept:
+        public init(
+          accept: [OpenAPIRuntime.AcceptHeaderContentType<
+            Operations.UpdateUserEmail.AcceptableContentType
+          >] = .defaultValues()
+        ) {
+          self.accept = accept
+        }
+      }
+      public var headers: Operations.UpdateUserEmail.Input.Headers
+      /// - Remark: Generated from `#/paths/public/v1/submit/update_user_email/POST/requestBody`.
+      @frozen public enum Body: Sendable, Hashable {
+        /// - Remark: Generated from `#/paths/public/v1/submit/update_user_email/POST/requestBody/content/application\/json`.
+        case json(Components.Schemas.UpdateUserEmailRequest)
+      }
+      public var body: Operations.UpdateUserEmail.Input.Body
+      /// Creates a new `Input`.
+      ///
+      /// - Parameters:
+      ///   - headers:
+      ///   - body:
+      public init(
+        headers: Operations.UpdateUserEmail.Input.Headers = .init(),
+        body: Operations.UpdateUserEmail.Input.Body
+      ) {
+        self.headers = headers
+        self.body = body
+      }
+    }
+    @frozen public enum Output: Sendable, Hashable {
+      public struct Ok: Sendable, Hashable {
+        /// - Remark: Generated from `#/paths/public/v1/submit/update_user_email/POST/responses/200/content`.
+        @frozen public enum Body: Sendable, Hashable {
+          /// - Remark: Generated from `#/paths/public/v1/submit/update_user_email/POST/responses/200/content/application\/json`.
+          case json(Components.Schemas.ActivityResponse)
+          /// The associated value of the enum case if `self` is `.json`.
+          ///
+          /// - Throws: An error if `self` is not `.json`.
+          /// - SeeAlso: `.json`.
+          public var json: Components.Schemas.ActivityResponse {
+            get throws {
+              switch self {
+              case let .json(body):
+                return body
+              }
+            }
+          }
+        }
+        /// Received HTTP response body
+        public var body: Operations.UpdateUserEmail.Output.Ok.Body
+        /// Creates a new `Ok`.
+        ///
+        /// - Parameters:
+        ///   - body: Received HTTP response body
+        public init(body: Operations.UpdateUserEmail.Output.Ok.Body) {
+          self.body = body
+        }
+      }
+      /// A successful response.
+      ///
+      /// - Remark: Generated from `#/paths//public/v1/submit/update_user_email/post(UpdateUserEmail)/responses/200`.
+      ///
+      /// HTTP response code: `200 ok`.
+      case ok(Operations.UpdateUserEmail.Output.Ok)
+      /// The associated value of the enum case if `self` is `.ok`.
+      ///
+      /// - Throws: An error if `self` is not `.ok`.
+      /// - SeeAlso: `.ok`.
+      public var ok: Operations.UpdateUserEmail.Output.Ok {
+        get throws {
+          switch self {
+          case let .ok(response):
+            return response
+          default:
+            try throwUnexpectedResponseStatus(
+              expectedStatus: "ok",
+              response: self
+            )
+          }
+        }
+      }
+      /// Undocumented response.
+      ///
+      /// A response with a code that is not documented in the OpenAPI document.
+      case undocumented(statusCode: Swift.Int, OpenAPIRuntime.UndocumentedPayload)
+    }
+    @frozen public enum AcceptableContentType: AcceptableProtocol {
+      case json
+      case other(Swift.String)
+      public init?(rawValue: Swift.String) {
+        switch rawValue.lowercased() {
+        case "application/json":
+          self = .json
+        default:
+          self = .other(rawValue)
+        }
+      }
+      public var rawValue: Swift.String {
+        switch self {
+        case let .other(string):
+          return string
+        case .json:
+          return "application/json"
+        }
+      }
+      public static var allCases: [Self] {
+        [
+          .json
+        ]
+      }
+    }
+  }
+  /// Update User's Name
+  ///
+  /// Update a User's name in an existing Organization
+  ///
+  /// - Remark: HTTP `POST /public/v1/submit/update_user_name`.
+  /// - Remark: Generated from `#/paths//public/v1/submit/update_user_name/post(UpdateUserName)`.
+  public enum UpdateUserName {
+    public static let id: Swift.String = "UpdateUserName"
+    public struct Input: Sendable, Hashable {
+      /// - Remark: Generated from `#/paths/public/v1/submit/update_user_name/POST/header`.
+      public struct Headers: Sendable, Hashable {
+        public var accept:
+          [OpenAPIRuntime.AcceptHeaderContentType<Operations.UpdateUserName.AcceptableContentType>]
+        /// Creates a new `Headers`.
+        ///
+        /// - Parameters:
+        ///   - accept:
+        public init(
+          accept: [OpenAPIRuntime.AcceptHeaderContentType<
+            Operations.UpdateUserName.AcceptableContentType
+          >] = .defaultValues()
+        ) {
+          self.accept = accept
+        }
+      }
+      public var headers: Operations.UpdateUserName.Input.Headers
+      /// - Remark: Generated from `#/paths/public/v1/submit/update_user_name/POST/requestBody`.
+      @frozen public enum Body: Sendable, Hashable {
+        /// - Remark: Generated from `#/paths/public/v1/submit/update_user_name/POST/requestBody/content/application\/json`.
+        case json(Components.Schemas.UpdateUserNameRequest)
+      }
+      public var body: Operations.UpdateUserName.Input.Body
+      /// Creates a new `Input`.
+      ///
+      /// - Parameters:
+      ///   - headers:
+      ///   - body:
+      public init(
+        headers: Operations.UpdateUserName.Input.Headers = .init(),
+        body: Operations.UpdateUserName.Input.Body
+      ) {
+        self.headers = headers
+        self.body = body
+      }
+    }
+    @frozen public enum Output: Sendable, Hashable {
+      public struct Ok: Sendable, Hashable {
+        /// - Remark: Generated from `#/paths/public/v1/submit/update_user_name/POST/responses/200/content`.
+        @frozen public enum Body: Sendable, Hashable {
+          /// - Remark: Generated from `#/paths/public/v1/submit/update_user_name/POST/responses/200/content/application\/json`.
+          case json(Components.Schemas.ActivityResponse)
+          /// The associated value of the enum case if `self` is `.json`.
+          ///
+          /// - Throws: An error if `self` is not `.json`.
+          /// - SeeAlso: `.json`.
+          public var json: Components.Schemas.ActivityResponse {
+            get throws {
+              switch self {
+              case let .json(body):
+                return body
+              }
+            }
+          }
+        }
+        /// Received HTTP response body
+        public var body: Operations.UpdateUserName.Output.Ok.Body
+        /// Creates a new `Ok`.
+        ///
+        /// - Parameters:
+        ///   - body: Received HTTP response body
+        public init(body: Operations.UpdateUserName.Output.Ok.Body) {
+          self.body = body
+        }
+      }
+      /// A successful response.
+      ///
+      /// - Remark: Generated from `#/paths//public/v1/submit/update_user_name/post(UpdateUserName)/responses/200`.
+      ///
+      /// HTTP response code: `200 ok`.
+      case ok(Operations.UpdateUserName.Output.Ok)
+      /// The associated value of the enum case if `self` is `.ok`.
+      ///
+      /// - Throws: An error if `self` is not `.ok`.
+      /// - SeeAlso: `.ok`.
+      public var ok: Operations.UpdateUserName.Output.Ok {
+        get throws {
+          switch self {
+          case let .ok(response):
+            return response
+          default:
+            try throwUnexpectedResponseStatus(
+              expectedStatus: "ok",
+              response: self
+            )
+          }
+        }
+      }
+      /// Undocumented response.
+      ///
+      /// A response with a code that is not documented in the OpenAPI document.
+      case undocumented(statusCode: Swift.Int, OpenAPIRuntime.UndocumentedPayload)
+    }
+    @frozen public enum AcceptableContentType: AcceptableProtocol {
+      case json
+      case other(Swift.String)
+      public init?(rawValue: Swift.String) {
+        switch rawValue.lowercased() {
+        case "application/json":
+          self = .json
+        default:
+          self = .other(rawValue)
+        }
+      }
+      public var rawValue: Swift.String {
+        switch self {
+        case let .other(string):
+          return string
+        case .json:
+          return "application/json"
+        }
+      }
+      public static var allCases: [Self] {
+        [
+          .json
+        ]
+      }
+    }
+  }
+  /// Update User's Phone Number
+  ///
+  /// Update a User's phone number in an existing Organization
+  ///
+  /// - Remark: HTTP `POST /public/v1/submit/update_user_phone_number`.
+  /// - Remark: Generated from `#/paths//public/v1/submit/update_user_phone_number/post(UpdateUserPhoneNumber)`.
+  public enum UpdateUserPhoneNumber {
+    public static let id: Swift.String = "UpdateUserPhoneNumber"
+    public struct Input: Sendable, Hashable {
+      /// - Remark: Generated from `#/paths/public/v1/submit/update_user_phone_number/POST/header`.
+      public struct Headers: Sendable, Hashable {
+        public var accept:
+          [OpenAPIRuntime.AcceptHeaderContentType<
+            Operations.UpdateUserPhoneNumber.AcceptableContentType
+          >]
+        /// Creates a new `Headers`.
+        ///
+        /// - Parameters:
+        ///   - accept:
+        public init(
+          accept: [OpenAPIRuntime.AcceptHeaderContentType<
+            Operations.UpdateUserPhoneNumber.AcceptableContentType
+          >] = .defaultValues()
+        ) {
+          self.accept = accept
+        }
+      }
+      public var headers: Operations.UpdateUserPhoneNumber.Input.Headers
+      /// - Remark: Generated from `#/paths/public/v1/submit/update_user_phone_number/POST/requestBody`.
+      @frozen public enum Body: Sendable, Hashable {
+        /// - Remark: Generated from `#/paths/public/v1/submit/update_user_phone_number/POST/requestBody/content/application\/json`.
+        case json(Components.Schemas.UpdateUserPhoneNumberRequest)
+      }
+      public var body: Operations.UpdateUserPhoneNumber.Input.Body
+      /// Creates a new `Input`.
+      ///
+      /// - Parameters:
+      ///   - headers:
+      ///   - body:
+      public init(
+        headers: Operations.UpdateUserPhoneNumber.Input.Headers = .init(),
+        body: Operations.UpdateUserPhoneNumber.Input.Body
+      ) {
+        self.headers = headers
+        self.body = body
+      }
+    }
+    @frozen public enum Output: Sendable, Hashable {
+      public struct Ok: Sendable, Hashable {
+        /// - Remark: Generated from `#/paths/public/v1/submit/update_user_phone_number/POST/responses/200/content`.
+        @frozen public enum Body: Sendable, Hashable {
+          /// - Remark: Generated from `#/paths/public/v1/submit/update_user_phone_number/POST/responses/200/content/application\/json`.
+          case json(Components.Schemas.ActivityResponse)
+          /// The associated value of the enum case if `self` is `.json`.
+          ///
+          /// - Throws: An error if `self` is not `.json`.
+          /// - SeeAlso: `.json`.
+          public var json: Components.Schemas.ActivityResponse {
+            get throws {
+              switch self {
+              case let .json(body):
+                return body
+              }
+            }
+          }
+        }
+        /// Received HTTP response body
+        public var body: Operations.UpdateUserPhoneNumber.Output.Ok.Body
+        /// Creates a new `Ok`.
+        ///
+        /// - Parameters:
+        ///   - body: Received HTTP response body
+        public init(body: Operations.UpdateUserPhoneNumber.Output.Ok.Body) {
+          self.body = body
+        }
+      }
+      /// A successful response.
+      ///
+      /// - Remark: Generated from `#/paths//public/v1/submit/update_user_phone_number/post(UpdateUserPhoneNumber)/responses/200`.
+      ///
+      /// HTTP response code: `200 ok`.
+      case ok(Operations.UpdateUserPhoneNumber.Output.Ok)
+      /// The associated value of the enum case if `self` is `.ok`.
+      ///
+      /// - Throws: An error if `self` is not `.ok`.
+      /// - SeeAlso: `.ok`.
+      public var ok: Operations.UpdateUserPhoneNumber.Output.Ok {
         get throws {
           switch self {
           case let .ok(response):

--- a/Sources/TurnkeyHttp/Internal/TurnkeyClient+Unwrap.swift
+++ b/Sources/TurnkeyHttp/Internal/TurnkeyClient+Unwrap.swift
@@ -2,35 +2,35 @@ import Foundation
 import OpenAPIRuntime
 
 extension TurnkeyClient {
-    @inline(__always)
-    internal func call<RawEnum, Ok>(
-        _ perform: () async throws -> RawEnum
-    ) async throws -> Ok {
-        let raw = try await perform()
-        return try await unwrapOK(raw) as! Ok
-    }
+  @inline(__always)
+  internal func call<RawEnum, Ok>(
+    _ perform: () async throws -> RawEnum
+  ) async throws -> Ok {
+    let raw = try await perform()
+    return try await unwrapOK(raw) as! Ok
+  }
 }
 
 @inline(__always)
 func unwrapOK<OutputEnum>(_ output: OutputEnum) async throws -> Any {
-    let mirror = Mirror(reflecting: output)
-    
-    // if it's .ok we return its associated value
-    if let child = mirror.children.first(where: { $0.label == "ok" }) {
-        return child.value
+  let mirror = Mirror(reflecting: output)
+
+  // if it's .ok we return its associated value
+  if let child = mirror.children.first(where: { $0.label == "ok" }) {
+    return child.value
+  }
+
+  // if it's .undocumented we map to TurnkeyError.apiError
+  if let child = mirror.children.first(where: { $0.label == "undocumented" }),
+    let tuple = child.value as? (statusCode: Int, payload: UndocumentedPayload)
+  {
+
+    var payloadData: Data?
+    if let body = tuple.payload.body {
+      payloadData = try await Data(collecting: body, upTo: .max)
     }
-    
-    // if it's .undocumented we map to TurnkeyError.apiError
-    if let child = mirror.children.first(where: { $0.label == "undocumented" }),
-       let tuple = child.value as? (statusCode: Int, payload: UndocumentedPayload)
-    {
-        
-        var payloadData: Data?
-        if let body = tuple.payload.body {
-            payloadData = try await Data(collecting: body, upTo: .max)
-        }
-        throw TurnkeyRequestError.apiError(statusCode: tuple.statusCode, payload: payloadData)
-    }
-    
-    throw TurnkeyRequestError.invalidResponse
+    throw TurnkeyRequestError.apiError(statusCode: tuple.statusCode, payload: payloadData)
+  }
+
+  throw TurnkeyRequestError.invalidResponse
 }

--- a/Sources/TurnkeyHttp/Models/Errors.swift
+++ b/Sources/TurnkeyHttp/Models/Errors.swift
@@ -3,73 +3,73 @@ import HTTPTypes
 
 /// A unified error type surfaced by the Turnkey Swift SDK.
 public enum TurnkeyRequestError: LocalizedError, Sendable, Equatable {
-    
-    case apiError(statusCode: Int?, payload: Data?)
-    case sdkError(Error)
-    case network(Error)
-    case invalidResponse
-    case unknown(Error)
-    
-    // helpers
-    public var statusCode: Int? {
-        if case let .apiError(code, _) = self { return code }
-        return nil
+
+  case apiError(statusCode: Int?, payload: Data?)
+  case sdkError(Error)
+  case network(Error)
+  case invalidResponse
+  case unknown(Error)
+
+  // helpers
+  public var statusCode: Int? {
+    if case let .apiError(code, _) = self { return code }
+    return nil
+  }
+
+  public var payload: Data? {
+    if case let .apiError(_, data) = self { return data }
+    return nil
+  }
+
+  /// pretty-prints either the JSON envelope or falls back to a raw string
+  public var fullMessage: String {
+    // try JSON first
+    if case let .apiError(_, data?) = self,
+      let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+      let json = try? JSONSerialization.data(
+        withJSONObject: obj, options: [.sortedKeys, .prettyPrinted]),
+      let str = String(data: json, encoding: .utf8)
+    {
+      return str
     }
-    
-    public var payload: Data? {
-        if case let .apiError(_, data) = self { return data }
-        return nil
+    // fallback raw utf-8
+    if case let .apiError(_, data?) = self,
+      let str = String(data: data, encoding: .utf8)
+    {
+      return str
     }
-    
-    /// pretty-prints either the JSON envelope or falls back to a raw string
-    public var fullMessage: String {
-        // try JSON first
-        if case let .apiError(_, data?) = self,
-           let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-           let json = try? JSONSerialization.data(
-            withJSONObject: obj, options: [.sortedKeys, .prettyPrinted]),
-           let str = String(data: json, encoding: .utf8)
-        {
-            return str
-        }
-        // fallback raw utf-8
-        if case let .apiError(_, data?) = self,
-           let str = String(data: data, encoding: .utf8)
-        {
-            return str
-        }
-        // this should never happen
-        return errorDescription ?? "Unknown error"
+    // this should never happen
+    return errorDescription ?? "Unknown error"
+  }
+
+  public var errorDescription: String? {
+    switch self {
+    case .apiError: return "Turnkey API returned an error response."
+    case .sdkError(let e): return e.localizedDescription
+    case .network(let e): return e.localizedDescription
+    case .invalidResponse: return "Invalid response from server."
+    case .unknown(let e): return e.localizedDescription
     }
-    
-    public var errorDescription: String? {
-        switch self {
-        case .apiError: return "Turnkey API returned an error response."
-        case .sdkError(let e): return e.localizedDescription
-        case .network(let e): return e.localizedDescription
-        case .invalidResponse: return "Invalid response from server."
-        case .unknown(let e): return e.localizedDescription
-        }
+  }
+
+  public init(httpResponse: HTTPResponse, body: Data?) {
+    let code = httpResponse.status.code
+    if (400..<600).contains(code) {
+      self = .apiError(statusCode: code, payload: body)
+    } else {
+      self = .unknown(NSError(domain: "TurnkeyError", code: code, userInfo: nil))
     }
-    
-    public init(httpResponse: HTTPResponse, body: Data?) {
-        let code = httpResponse.status.code
-        if (400..<600).contains(code) {
-            self = .apiError(statusCode: code, payload: body)
-        } else {
-            self = .unknown(NSError(domain: "TurnkeyError", code: code, userInfo: nil))
-        }
+  }
+
+  public init(_ error: Error) {
+    self = error as? TurnkeyRequestError ?? .unknown(error)
+  }
+
+  public static func == (lhs: Self, rhs: Self) -> Bool {
+    switch (lhs, rhs) {
+    case let (.apiError(c1, d1), .apiError(c2, d2)): return c1 == c2 && d1 == d2
+    case (.invalidResponse, .invalidResponse): return true
+    default: return false
     }
-    
-    public init(_ error: Error) {
-        self = error as? TurnkeyRequestError ?? .unknown(error)
-    }
-    
-    public static func == (lhs: Self, rhs: Self) -> Bool {
-        switch (lhs, rhs) {
-        case let (.apiError(c1, d1), .apiError(c2, d2)): return c1 == c2 && d1 == d2
-        case (.invalidResponse, .invalidResponse): return true
-        default: return false
-        }
-    }
+  }
 }

--- a/Sources/TurnkeyHttp/Public/TurnkeyClient.swift
+++ b/Sources/TurnkeyHttp/Public/TurnkeyClient.swift
@@ -1663,7 +1663,7 @@ public struct TurnkeyClient {
 
   public func setOrganizationFeature(
     organizationId: String,
-    name: Components.Schemas.FeatureName, value: String
+    name: Components.Schemas.FeatureName, value: String?
   ) async throws -> Operations.SetOrganizationFeature.Output.Ok {
 
     // Create the SetOrganizationFeatureIntent
@@ -1911,6 +1911,87 @@ public struct TurnkeyClient {
 
     // Call the UpdateUser method using the underlyingClient
     return try await call { try await underlyingClient.UpdateUser(input) }
+  }
+
+  public func updateUserEmail(
+    organizationId: String,
+    userId: String, userEmail: String, verificationToken: String?
+  ) async throws -> Operations.UpdateUserEmail.Output.Ok {
+
+    // Create the UpdateUserEmailIntent
+    let updateUserEmailIntent = Components.Schemas.UpdateUserEmailIntent(
+      userId: userId, userEmail: userEmail, verificationToken: verificationToken)
+
+    // Create the UpdateUserEmailRequest
+    let updateUserEmailRequest = Components.Schemas.UpdateUserEmailRequest(
+      _type: .ACTIVITY_TYPE_UPDATE_USER_EMAIL,
+      timestampMs: String(Int(Date().timeIntervalSince1970 * 1000)),
+      organizationId: organizationId,
+      parameters: updateUserEmailIntent
+    )
+
+    // Create the input for the UpdateUserEmail method
+    let input = Operations.UpdateUserEmail.Input(
+      headers: .init(accept: [.init(contentType: .json)]),
+      body: .json(updateUserEmailRequest)
+    )
+
+    // Call the UpdateUserEmail method using the underlyingClient
+    return try await call { try await underlyingClient.UpdateUserEmail(input) }
+  }
+
+  public func updateUserName(
+    organizationId: String,
+    userId: String, userName: String
+  ) async throws -> Operations.UpdateUserName.Output.Ok {
+
+    // Create the UpdateUserNameIntent
+    let updateUserNameIntent = Components.Schemas.UpdateUserNameIntent(
+      userId: userId, userName: userName)
+
+    // Create the UpdateUserNameRequest
+    let updateUserNameRequest = Components.Schemas.UpdateUserNameRequest(
+      _type: .ACTIVITY_TYPE_UPDATE_USER_NAME,
+      timestampMs: String(Int(Date().timeIntervalSince1970 * 1000)),
+      organizationId: organizationId,
+      parameters: updateUserNameIntent
+    )
+
+    // Create the input for the UpdateUserName method
+    let input = Operations.UpdateUserName.Input(
+      headers: .init(accept: [.init(contentType: .json)]),
+      body: .json(updateUserNameRequest)
+    )
+
+    // Call the UpdateUserName method using the underlyingClient
+    return try await call { try await underlyingClient.UpdateUserName(input) }
+  }
+
+  public func updateUserPhoneNumber(
+    organizationId: String,
+    userId: String, userPhoneNumber: String, verificationToken: String?
+  ) async throws -> Operations.UpdateUserPhoneNumber.Output.Ok {
+
+    // Create the UpdateUserPhoneNumberIntent
+    let updateUserPhoneNumberIntent = Components.Schemas.UpdateUserPhoneNumberIntent(
+      userId: userId, userPhoneNumber: userPhoneNumber, verificationToken: verificationToken)
+
+    // Create the UpdateUserPhoneNumberRequest
+    let updateUserPhoneNumberRequest = Components.Schemas.UpdateUserPhoneNumberRequest(
+      _type: .ACTIVITY_TYPE_UPDATE_USER_PHONE_NUMBER,
+      timestampMs: String(Int(Date().timeIntervalSince1970 * 1000)),
+      organizationId: organizationId,
+      parameters: updateUserPhoneNumberIntent
+    )
+
+    // Create the input for the UpdateUserPhoneNumber method
+    let input = Operations.UpdateUserPhoneNumber.Input(
+      headers: .init(accept: [.init(contentType: .json)]),
+      body: .json(updateUserPhoneNumberRequest)
+    )
+
+    // Call the UpdateUserPhoneNumber method using the underlyingClient
+    return try await call { try await underlyingClient.UpdateUserPhoneNumber(input) }
   }
 
   public func updateUserTag(

--- a/Sources/TurnkeyHttp/Resources/openapi.yaml
+++ b/Sources/TurnkeyHttp/Resources/openapi.yaml
@@ -1698,6 +1698,69 @@ paths:
               schema:
                 $ref: '#/components/schemas/ActivityResponse'
       x-codegen-request-body-name: body
+  /public/v1/submit/update_user_email:
+    post:
+      tags:
+      - Users
+      summary: Update User's Email
+      description: Update a User's email in an existing Organization
+      operationId: UpdateUserEmail
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateUserEmailRequest'
+        required: true
+      responses:
+        "200":
+          description: A successful response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ActivityResponse'
+      x-codegen-request-body-name: body
+  /public/v1/submit/update_user_name:
+    post:
+      tags:
+      - Users
+      summary: Update User's Name
+      description: Update a User's name in an existing Organization
+      operationId: UpdateUserName
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateUserNameRequest'
+        required: true
+      responses:
+        "200":
+          description: A successful response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ActivityResponse'
+      x-codegen-request-body-name: body
+  /public/v1/submit/update_user_phone_number:
+    post:
+      tags:
+      - Users
+      summary: Update User's Phone Number
+      description: Update a User's phone number in an existing Organization
+      operationId: UpdateUserPhoneNumber
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateUserPhoneNumberRequest'
+        required: true
+      responses:
+        "200":
+          description: A successful response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ActivityResponse'
+      x-codegen-request-body-name: body
   /public/v1/submit/update_user_tag:
     post:
       tags:
@@ -1985,6 +2048,9 @@ components:
       - ACTIVITY_TYPE_OTP_LOGIN
       - ACTIVITY_TYPE_STAMP_LOGIN
       - ACTIVITY_TYPE_OAUTH_LOGIN
+      - ACTIVITY_TYPE_UPDATE_USER_NAME
+      - ACTIVITY_TYPE_UPDATE_USER_EMAIL
+      - ACTIVITY_TYPE_UPDATE_USER_PHONE_NUMBER
     AddressFormat:
       type: string
       enum:
@@ -2022,6 +2088,7 @@ components:
       - ADDRESS_FORMAT_DOGE_TESTNET
       - ADDRESS_FORMAT_TON_V3R2
       - ADDRESS_FORMAT_TON_V4R2
+      - ADDRESS_FORMAT_TON_V5R1
       - ADDRESS_FORMAT_XRP
     Any:
       type: object
@@ -2056,6 +2123,7 @@ components:
           description: Optional window (in seconds) indicating how long the API Key
             should last.
           format: uint64
+          nullable: true
     ApiKeyCurve:
       type: string
       enum:
@@ -2079,6 +2147,7 @@ components:
           type: string
           description: Optional window (in seconds) indicating how long the API Key
             should last.
+          nullable: true
     ApiKeyParamsV2:
       required:
       - apiKeyName
@@ -2099,6 +2168,7 @@ components:
           type: string
           description: Optional window (in seconds) indicating how long the API Key
             should last.
+          nullable: true
     ApiOnlyUserParams:
       required:
       - apiKeys
@@ -2112,6 +2182,7 @@ components:
         userEmail:
           type: string
           description: The email address for this API-only User (optional).
+          nullable: true
         userTags:
           type: array
           description: "A list of tags assigned to the new API-only User. This field,\
@@ -2533,6 +2604,7 @@ components:
         rootUserId:
           type: string
           description: Unique identifier for the root user object.
+          nullable: true
     CreateOrganizationIntentV2:
       required:
       - organizationName
@@ -2551,6 +2623,7 @@ components:
         rootUserId:
           type: string
           description: Unique identifier for the root user object.
+          nullable: true
     CreateOrganizationResult:
       required:
       - organizationId
@@ -2654,9 +2727,11 @@ components:
         condition:
           type: string
           description: The condition expression that triggers the Effect
+          nullable: true
         consensus:
           type: string
           description: The consensus expression that triggers the Effect
+          nullable: true
         notes:
           type: string
     CreatePolicyRequest:
@@ -2871,10 +2946,12 @@ components:
           type: string
           description: "Optional human-readable name for an API Key. If none provided,\
             \ default to Read Write Session - <Timestamp>"
+          nullable: true
         expirationSeconds:
           type: string
           description: "Expiration window (in seconds) indicating how long the API\
             \ key is valid for. If not provided, a default of 15 minutes will be used."
+          nullable: true
     CreateReadWriteSessionIntentV2:
       required:
       - targetPublicKey
@@ -2887,18 +2964,22 @@ components:
         userId:
           type: string
           description: Unique identifier for a given User.
+          nullable: true
         apiKeyName:
           type: string
           description: "Optional human-readable name for an API Key. If none provided,\
             \ default to Read Write Session - <Timestamp>"
+          nullable: true
         expirationSeconds:
           type: string
           description: "Expiration window (in seconds) indicating how long the API\
             \ key is valid for. If not provided, a default of 15 minutes will be used."
+          nullable: true
         invalidateExisting:
           type: boolean
           description: Invalidate all other previously generated ReadWriteSession
             API keys
+          nullable: true
     CreateReadWriteSessionRequest:
       required:
       - organizationId
@@ -3064,9 +3145,11 @@ components:
         disableEmailRecovery:
           type: boolean
           description: Disable email recovery for the sub-organization
+          nullable: true
         disableEmailAuth:
           type: boolean
           description: Disable email auth for the sub-organization
+          nullable: true
     CreateSubOrganizationIntentV5:
       required:
       - rootQuorumThreshold
@@ -3092,9 +3175,11 @@ components:
         disableEmailRecovery:
           type: boolean
           description: Disable email recovery for the sub-organization
+          nullable: true
         disableEmailAuth:
           type: boolean
           description: Disable email auth for the sub-organization
+          nullable: true
     CreateSubOrganizationIntentV6:
       required:
       - rootQuorumThreshold
@@ -3120,9 +3205,11 @@ components:
         disableEmailRecovery:
           type: boolean
           description: Disable email recovery for the sub-organization
+          nullable: true
         disableEmailAuth:
           type: boolean
           description: Disable email auth for the sub-organization
+          nullable: true
     CreateSubOrganizationIntentV7:
       required:
       - rootQuorumThreshold
@@ -3148,15 +3235,19 @@ components:
         disableEmailRecovery:
           type: boolean
           description: Disable email recovery for the sub-organization
+          nullable: true
         disableEmailAuth:
           type: boolean
           description: Disable email auth for the sub-organization
+          nullable: true
         disableSmsAuth:
           type: boolean
           description: Disable OTP SMS auth for the sub-organization
+          nullable: true
         disableOtpEmailAuth:
           type: boolean
           description: Disable OTP email auth for the sub-organization
+          nullable: true
     CreateSubOrganizationRequest:
       required:
       - organizationId
@@ -3433,6 +3524,7 @@ components:
           description: "Length of mnemonic to generate the Wallet seed. Defaults to\
             \ 12. Accepted values: 12, 15, 18, 21, 24."
           format: int32
+          nullable: true
     CreateWalletRequest:
       required:
       - organizationId
@@ -3689,6 +3781,7 @@ components:
         paymentMethodId:
           type: string
           description: The payment method that the customer wants to remove.
+          nullable: true
     DeletePaymentMethodResult:
       required:
       - paymentMethodId
@@ -3796,6 +3889,7 @@ components:
           description: "Optional parameter for deleting the private keys, even if\
             \ any have not been previously exported. If they have been exported, this\
             \ field is ignored."
+          nullable: true
     DeletePrivateKeysRequest:
       required:
       - organizationId
@@ -3836,6 +3930,7 @@ components:
             \ wallets and private keys to be exported for security reasons. Set this\
             \ boolean to true to force sub-organization deletion even if some wallets\
             \ or private keys within it have not been exported yet. Default: false."
+          nullable: true
     DeleteSubOrganizationRequest:
       required:
       - organizationId
@@ -3968,6 +4063,7 @@ components:
           description: "Optional parameter for deleting the wallets, even if any have\
             \ not been previously exported. If they have been exported, this field\
             \ is ignored."
+          nullable: true
     DeleteWalletsRequest:
       required:
       - organizationId
@@ -4037,25 +4133,31 @@ components:
           type: string
           description: "Optional human-readable name for an API Key. If none provided,\
             \ default to Email Auth - <Timestamp>"
+          nullable: true
         expirationSeconds:
           type: string
           description: "Expiration window (in seconds) indicating how long the API\
             \ key is valid for. If not provided, a default of 15 minutes will be used."
+          nullable: true
         emailCustomization:
           $ref: '#/components/schemas/EmailCustomizationParams'
         invalidateExisting:
           type: boolean
           description: Invalidate all other previously generated Email Auth API keys
+          nullable: true
         sendFromEmailAddress:
           type: string
           description: Optional custom email address from which to send the email
+          nullable: true
         sendFromEmailSenderName:
           type: string
           description: "Optional custom sender name for use with sendFromEmailAddress;\
             \ if left empty, will default to 'Notifications'"
+          nullable: true
         replyToEmailAddress:
           type: string
           description: Optional custom email address to use as reply-to
+          nullable: true
     EmailAuthIntentV2:
       required:
       - email
@@ -4073,25 +4175,31 @@ components:
           type: string
           description: "Optional human-readable name for an API Key. If none provided,\
             \ default to Email Auth - <Timestamp>"
+          nullable: true
         expirationSeconds:
           type: string
           description: "Expiration window (in seconds) indicating how long the API\
             \ key is valid for. If not provided, a default of 15 minutes will be used."
+          nullable: true
         emailCustomization:
           $ref: '#/components/schemas/EmailCustomizationParams'
         invalidateExisting:
           type: boolean
           description: Invalidate all other previously generated Email Auth API keys
+          nullable: true
         sendFromEmailAddress:
           type: string
           description: Optional custom email address from which to send the email
+          nullable: true
         sendFromEmailSenderName:
           type: string
           description: "Optional custom sender name for use with sendFromEmailAddress;\
             \ if left empty, will default to 'Notifications'"
+          nullable: true
         replyToEmailAddress:
           type: string
           description: Optional custom email address to use as reply-to
+          nullable: true
     EmailAuthRequest:
       required:
       - organizationId
@@ -4131,23 +4239,28 @@ components:
         appName:
           type: string
           description: The name of the application.
+          nullable: true
         logoUrl:
           type: string
           description: A URL pointing to a logo in PNG format. Note this logo will
             be resized to fit into 340px x 124px.
+          nullable: true
         magicLinkTemplate:
           type: string
           description: "A template for the URL to be used in a magic link button,\
             \ e.g. `https://dapp.xyz/%s`. The auth bundle will be interpolated into\
             \ the `%s`."
+          nullable: true
         templateVariables:
           type: string
           description: JSON object containing key/value pairs to be used with custom
             templates.
+          nullable: true
         templateId:
           type: string
           description: "Unique identifier for a given Email Template. If not specified,\
             \ the default is the most recent Email Template."
+          nullable: true
     ExportPrivateKeyIntent:
       required:
       - privateKeyId
@@ -4298,6 +4411,7 @@ components:
           $ref: '#/components/schemas/FeatureName'
         value:
           type: string
+          nullable: true
     FeatureName:
       type: string
       enum:
@@ -4382,6 +4496,7 @@ components:
         userId:
           type: string
           description: Unique identifier for a given User.
+          nullable: true
     GetApiKeysResponse:
       required:
       - apiKeys
@@ -4444,6 +4559,7 @@ components:
         userId:
           type: string
           description: Unique identifier for a given User.
+          nullable: true
     GetOauthProvidersResponse:
       required:
       - oauthProviders
@@ -4652,9 +4768,11 @@ components:
         address:
           type: string
           description: Address corresponding to a Wallet Account.
+          nullable: true
         path:
           type: string
           description: Path corresponding to a Wallet Account.
+          nullable: true
     GetWalletAccountResponse:
       required:
       - account
@@ -4979,16 +5097,20 @@ components:
           description: Optional client-generated user identifier to enable per-user
             rate limiting for SMS auth. We recommend using a hash of the client-side
             IP address.
+          nullable: true
         sendFromEmailAddress:
           type: string
           description: Optional custom email address from which to send the OTP email
+          nullable: true
         sendFromEmailSenderName:
           type: string
           description: "Optional custom sender name for use with sendFromEmailAddress;\
             \ if left empty, will default to 'Notifications'"
+          nullable: true
         replyToEmailAddress:
           type: string
           description: Optional custom email address to use as reply-to
+          nullable: true
     InitOtpAuthIntentV2:
       required:
       - contact
@@ -5005,6 +5127,7 @@ components:
           type: integer
           description: Optional length of the OTP code. Default = 9
           format: int32
+          nullable: true
         emailCustomization:
           $ref: '#/components/schemas/EmailCustomizationParams'
         smsCustomization:
@@ -5014,20 +5137,25 @@ components:
           description: Optional client-generated user identifier to enable per-user
             rate limiting for SMS auth. We recommend using a hash of the client-side
             IP address.
+          nullable: true
         sendFromEmailAddress:
           type: string
           description: Optional custom email address from which to send the OTP email
+          nullable: true
         alphanumeric:
           type: boolean
           description: Optional flag to specify if the OTP code should be alphanumeric
             (Crockford’s Base32). Default = true
+          nullable: true
         sendFromEmailSenderName:
           type: string
           description: "Optional custom sender name for use with sendFromEmailAddress;\
             \ if left empty, will default to 'Notifications'"
+          nullable: true
         replyToEmailAddress:
           type: string
           description: Optional custom email address to use as reply-to
+          nullable: true
     InitOtpAuthRequest:
       required:
       - organizationId
@@ -5082,6 +5210,7 @@ components:
           type: integer
           description: Optional length of the OTP code. Default = 9
           format: int32
+          nullable: true
         emailCustomization:
           $ref: '#/components/schemas/EmailCustomizationParams'
         smsCustomization:
@@ -5091,25 +5220,31 @@ components:
           description: Optional client-generated user identifier to enable per-user
             rate limiting for SMS auth. We recommend using a hash of the client-side
             IP address.
+          nullable: true
         sendFromEmailAddress:
           type: string
           description: Optional custom email address from which to send the OTP email
+          nullable: true
         alphanumeric:
           type: boolean
           description: Optional flag to specify if the OTP code should be alphanumeric
             (Crockford’s Base32). Default = true
+          nullable: true
         sendFromEmailSenderName:
           type: string
           description: "Optional custom sender name for use with sendFromEmailAddress;\
             \ if left empty, will default to 'Notifications'"
+          nullable: true
         expirationSeconds:
           type: string
           description: "Expiration window (in seconds) indicating how long the OTP\
             \ is valid for. If not provided, a default of 5 minutes will be used.\
             \ Maximum value is 600 seconds (10 minutes)"
+          nullable: true
         replyToEmailAddress:
           type: string
           description: Optional custom email address to use as reply-to
+          nullable: true
     InitOtpRequest:
       required:
       - organizationId
@@ -5157,6 +5292,7 @@ components:
           description: "Expiration window (in seconds) indicating how long the recovery\
             \ credential is valid for. If not provided, a default of 15 minutes will\
             \ be used."
+          nullable: true
         emailCustomization:
           $ref: '#/components/schemas/EmailCustomizationParams'
     InitUserEmailRecoveryRequest:
@@ -5367,6 +5503,12 @@ components:
           $ref: '#/components/schemas/StampLoginIntent'
         oauthLoginIntent:
           $ref: '#/components/schemas/OauthLoginIntent'
+        updateUserNameIntent:
+          $ref: '#/components/schemas/UpdateUserNameIntent'
+        updateUserEmailIntent:
+          $ref: '#/components/schemas/UpdateUserEmailIntent'
+        updateUserPhoneNumberIntent:
+          $ref: '#/components/schemas/UpdateUserPhoneNumberIntent'
     InvitationParams:
       required:
       - accessType
@@ -5458,13 +5600,16 @@ components:
           type: string
           description: "Optional human-readable name for an API Key. If none provided,\
             \ default to Oauth - <Timestamp>"
+          nullable: true
         expirationSeconds:
           type: string
           description: "Expiration window (in seconds) indicating how long the API\
             \ key is valid for. If not provided, a default of 15 minutes will be used."
+          nullable: true
         invalidateExisting:
           type: boolean
           description: Invalidate all other previously generated Oauth API keys
+          nullable: true
     OauthLoginIntent:
       required:
       - oidcToken
@@ -5483,9 +5628,11 @@ components:
           type: string
           description: "Expiration window (in seconds) indicating how long the Session\
             \ is valid for. If not provided, a default of 15 minutes will be used."
+          nullable: true
         invalidateExisting:
           type: boolean
           description: Invalidate all other previously generated Login API keys
+          nullable: true
     OauthLoginRequest:
       required:
       - organizationId
@@ -5633,13 +5780,16 @@ components:
           type: string
           description: "Optional human-readable name for an API Key. If none provided,\
             \ default to OTP Auth - <Timestamp>"
+          nullable: true
         expirationSeconds:
           type: string
           description: "Expiration window (in seconds) indicating how long the API\
             \ key is valid for. If not provided, a default of 15 minutes will be used."
+          nullable: true
         invalidateExisting:
           type: boolean
           description: Invalidate all other previously generated OTP Auth API keys
+          nullable: true
     OtpAuthRequest:
       required:
       - organizationId
@@ -5694,9 +5844,11 @@ components:
           type: string
           description: "Expiration window (in seconds) indicating how long the Session\
             \ is valid for. If not provided, a default of 15 minutes will be used."
+          nullable: true
         invalidateExisting:
           type: boolean
           description: Invalidate all other previously generated Login API keys
+          nullable: true
     OtpLoginRequest:
       required:
       - organizationId
@@ -5782,9 +5934,11 @@ components:
         consensus:
           type: string
           description: A consensus expression that evalutes to true or false.
+          nullable: true
         condition:
           type: string
           description: A condition expression that evalutes to true or false.
+          nullable: true
     PrivateKey:
       required:
       - addresses
@@ -6150,6 +6304,12 @@ components:
           $ref: '#/components/schemas/StampLoginResult'
         oauthLoginResult:
           $ref: '#/components/schemas/OauthLoginResult'
+        updateUserNameResult:
+          $ref: '#/components/schemas/UpdateUserNameResult'
+        updateUserEmailResult:
+          $ref: '#/components/schemas/UpdateUserEmailResult'
+        updateUserPhoneNumberResult:
+          $ref: '#/components/schemas/UpdateUserPhoneNumberResult'
     RootUserParams:
       required:
       - apiKeys
@@ -6163,6 +6323,7 @@ components:
         userEmail:
           type: string
           description: The user's email address.
+          nullable: true
         apiKeys:
           type: array
           description: "A list of API Key parameters. This field, if not needed, should\
@@ -6189,6 +6350,7 @@ components:
         userEmail:
           type: string
           description: The user's email address.
+          nullable: true
         apiKeys:
           type: array
           description: "A list of API Key parameters. This field, if not needed, should\
@@ -6221,6 +6383,7 @@ components:
         userEmail:
           type: string
           description: The user's email address.
+          nullable: true
         apiKeys:
           type: array
           description: "A list of API Key parameters. This field, if not needed, should\
@@ -6253,9 +6416,11 @@ components:
         userEmail:
           type: string
           description: The user's email address.
+          nullable: true
         userPhoneNumber:
           type: string
           description: The user's phone number in E.164 format e.g. +13214567890
+          nullable: true
         apiKeys:
           type: array
           description: "A list of API Key parameters. This field, if not needed, should\
@@ -6306,6 +6471,7 @@ components:
           type: string
           description: Optional value for the feature. Will override existing values
             if feature is already set.
+          nullable: true
     SetOrganizationFeatureRequest:
       required:
       - organizationId
@@ -6585,8 +6751,10 @@ components:
       properties:
         appid:
           type: boolean
+          nullable: true
         appidExclude:
           type: boolean
+          nullable: true
         credProps:
           $ref: '#/components/schemas/CredPropsAuthenticationExtensionsClientOutputs'
     SmsCustomizationParams:
@@ -6596,6 +6764,7 @@ components:
           type: string
           description: "Template containing references to .OtpCode i.e Your OTP is\
             \ {{.OtpCode}}"
+          nullable: true
     StampLoginIntent:
       required:
       - publicKey
@@ -6610,9 +6779,11 @@ components:
           type: string
           description: "Expiration window (in seconds) indicating how long the Session\
             \ is valid for. If not provided, a default of 15 minutes will be used."
+          nullable: true
         invalidateExisting:
           type: boolean
           description: Invalidate all other previously generated Login API keys
+          nullable: true
     StampLoginRequest:
       required:
       - organizationId
@@ -6690,17 +6861,21 @@ components:
         policyName:
           type: string
           description: Human-readable name for a Policy.
+          nullable: true
         policyEffect:
           $ref: '#/components/schemas/Effect'
         policyCondition:
           type: string
           description: The condition expression that triggers the Effect (optional).
+          nullable: true
         policyConsensus:
           type: string
           description: The consensus expression that triggers the Effect (optional).
+          nullable: true
         policyNotes:
           type: string
           description: Accompanying notes for a Policy (optional).
+          nullable: true
     UpdatePolicyIntentV2:
       required:
       - policyId
@@ -6712,17 +6887,21 @@ components:
         policyName:
           type: string
           description: Human-readable name for a Policy.
+          nullable: true
         policyEffect:
           $ref: '#/components/schemas/Effect'
         policyCondition:
           type: string
           description: The condition expression that triggers the Effect (optional).
+          nullable: true
         policyConsensus:
           type: string
           description: The consensus expression that triggers the Effect (optional).
+          nullable: true
         policyNotes:
           type: string
           description: Accompanying notes for a Policy (optional).
+          nullable: true
     UpdatePolicyRequest:
       required:
       - organizationId
@@ -6773,6 +6952,7 @@ components:
         newPrivateKeyTagName:
           type: string
           description: "The new, human-readable name for the tag with the given ID."
+          nullable: true
         addPrivateKeyIds:
           type: array
           description: A list of Private Keys IDs to add this tag to.
@@ -6850,6 +7030,53 @@ components:
           $ref: '#/components/schemas/UpdateRootQuorumIntent'
     UpdateRootQuorumResult:
       type: object
+    UpdateUserEmailIntent:
+      required:
+      - userEmail
+      - userId
+      type: object
+      properties:
+        userId:
+          type: string
+          description: Unique identifier for a given User.
+        userEmail:
+          type: string
+          description: The user's email address. Setting this to an empty string will
+            remove the user's email.
+        verificationToken:
+          type: string
+          description: "Signed JWT containing a unique id, expiry, verification type,\
+            \ contact"
+          nullable: true
+    UpdateUserEmailRequest:
+      required:
+      - organizationId
+      - parameters
+      - timestampMs
+      - type
+      type: object
+      properties:
+        type:
+          type: string
+          enum:
+          - ACTIVITY_TYPE_UPDATE_USER_EMAIL
+        timestampMs:
+          type: string
+          description: "Timestamp (in milliseconds) of the request, used to verify\
+            \ liveness of user requests."
+        organizationId:
+          type: string
+          description: Unique identifier for a given Organization.
+        parameters:
+          $ref: '#/components/schemas/UpdateUserEmailIntent'
+    UpdateUserEmailResult:
+      required:
+      - userId
+      type: object
+      properties:
+        userId:
+          type: string
+          description: Unique identifier of the User whose email was updated.
     UpdateUserIntent:
       required:
       - userId
@@ -6861,9 +7088,11 @@ components:
         userName:
           type: string
           description: Human-readable name for a User.
+          nullable: true
         userEmail:
           type: string
           description: The user's email address.
+          nullable: true
         userTagIds:
           type: array
           description: "An updated list of User Tags to apply to this User. This field,\
@@ -6873,6 +7102,95 @@ components:
         userPhoneNumber:
           type: string
           description: The user's phone number in E.164 format e.g. +13214567890
+          nullable: true
+    UpdateUserNameIntent:
+      required:
+      - userId
+      - userName
+      type: object
+      properties:
+        userId:
+          type: string
+          description: Unique identifier for a given User.
+        userName:
+          type: string
+          description: Human-readable name for a User.
+    UpdateUserNameRequest:
+      required:
+      - organizationId
+      - parameters
+      - timestampMs
+      - type
+      type: object
+      properties:
+        type:
+          type: string
+          enum:
+          - ACTIVITY_TYPE_UPDATE_USER_NAME
+        timestampMs:
+          type: string
+          description: "Timestamp (in milliseconds) of the request, used to verify\
+            \ liveness of user requests."
+        organizationId:
+          type: string
+          description: Unique identifier for a given Organization.
+        parameters:
+          $ref: '#/components/schemas/UpdateUserNameIntent'
+    UpdateUserNameResult:
+      required:
+      - userId
+      type: object
+      properties:
+        userId:
+          type: string
+          description: Unique identifier of the User whose name was updated.
+    UpdateUserPhoneNumberIntent:
+      required:
+      - userId
+      - userPhoneNumber
+      type: object
+      properties:
+        userId:
+          type: string
+          description: Unique identifier for a given User.
+        userPhoneNumber:
+          type: string
+          description: The user's phone number in E.164 format e.g. +13214567890.
+            Setting this to an empty string will remove the user's phone number.
+        verificationToken:
+          type: string
+          description: "Signed JWT containing a unique id, expiry, verification type,\
+            \ contact"
+          nullable: true
+    UpdateUserPhoneNumberRequest:
+      required:
+      - organizationId
+      - parameters
+      - timestampMs
+      - type
+      type: object
+      properties:
+        type:
+          type: string
+          enum:
+          - ACTIVITY_TYPE_UPDATE_USER_PHONE_NUMBER
+        timestampMs:
+          type: string
+          description: "Timestamp (in milliseconds) of the request, used to verify\
+            \ liveness of user requests."
+        organizationId:
+          type: string
+          description: Unique identifier for a given Organization.
+        parameters:
+          $ref: '#/components/schemas/UpdateUserPhoneNumberIntent'
+    UpdateUserPhoneNumberResult:
+      required:
+      - userId
+      type: object
+      properties:
+        userId:
+          type: string
+          description: Unique identifier of the User whose phone number was updated.
     UpdateUserRequest:
       required:
       - organizationId
@@ -6915,6 +7233,7 @@ components:
         newUserTagName:
           type: string
           description: "The new, human-readable name for the tag with the given ID."
+          nullable: true
         addUserIds:
           type: array
           description: A list of User IDs to add this tag to.
@@ -7015,9 +7334,11 @@ components:
         userEmail:
           type: string
           description: The user's email address.
+          nullable: true
         userPhoneNumber:
           type: string
           description: The user's phone number in E.164 format e.g. +13214567890
+          nullable: true
         authenticators:
           type: array
           description: A list of Authenticator parameters.
@@ -7058,6 +7379,7 @@ components:
         userEmail:
           type: string
           description: The user's email address.
+          nullable: true
         accessType:
           $ref: '#/components/schemas/AccessType'
         apiKeys:
@@ -7092,6 +7414,7 @@ components:
         userEmail:
           type: string
           description: The user's email address.
+          nullable: true
         apiKeys:
           type: array
           description: "A list of API Key parameters. This field, if not needed, should\
@@ -7125,9 +7448,11 @@ components:
         userEmail:
           type: string
           description: The user's email address.
+          nullable: true
         userPhoneNumber:
           type: string
           description: The user's phone number in E.164 format e.g. +13214567890
+          nullable: true
         apiKeys:
           type: array
           description: "A list of API Key parameters. This field, if not needed, should\
@@ -7169,6 +7494,7 @@ components:
           description: "Expiration window (in seconds) indicating how long the verification\
             \ token is valid for. If not provided, a default of 1 hour will be used.\
             \ Maximum value is 86400 seconds (24 hours)"
+          nullable: true
     VerifyOtpRequest:
       required:
       - organizationId
@@ -7198,7 +7524,8 @@ components:
         verificationToken:
           type: string
           description: "Signed JWT containing a unique id, expiry, verification type,\
-            \ contact"
+            \ contact. Verification status of a user is updated when the token is\
+            \ consumed (in OTP_LOGIN requests)"
     Vote:
       required:
       - activityId
@@ -7313,6 +7640,7 @@ components:
           type: string
           description: The public component of this wallet account's underlying cryptographic
             key pair.
+          nullable: true
     WalletAccountParams:
       required:
       - addressFormat
@@ -7350,6 +7678,7 @@ components:
           description: "Length of mnemonic to generate the Wallet seed. Defaults to\
             \ 12. Accepted values: 12, 15, 18, 21, 24."
           format: int32
+          nullable: true
     WalletResult:
       required:
       - addresses

--- a/Sources/TurnkeySwift/Internal/Storage/Sessions/AutoRefreshStore.swift
+++ b/Sources/TurnkeySwift/Internal/Storage/Sessions/AutoRefreshStore.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+/// Stores the auto-refresh duration (in seconds) for each session key.
+/// Used to drive automatic session refreshes before JWT expiry.
+enum AutoRefreshStore {
+    private static let storeKey = Constants.Storage.autoRefreshStoreKey
+    private static let q = DispatchQueue(label: "autoRefreshStore", attributes: .concurrent)
+    
+    static func set(durationSeconds: String, for sessionKey: String) throws {
+        try q.sync(flags: .barrier) {
+            var dict = (try? LocalStore.get(storeKey) as [String: String]?) ?? [:]
+            dict[sessionKey] = durationSeconds
+            try LocalStore.set(dict, for: storeKey)
+        }
+    }
+    
+    static func remove(for sessionKey: String) throws {
+        try q.sync(flags: .barrier) {
+            var dict = (try? LocalStore.get(storeKey) as [String: String]?) ?? [:]
+            dict.removeValue(forKey: sessionKey)
+            try LocalStore.set(dict, for: storeKey)
+        }
+    }
+    
+    static func durationSeconds(for sessionKey: String) -> String? {
+        q.sync {
+            let dict = (try? LocalStore.get(storeKey) as [String: String]?) ?? [:]
+            return dict[sessionKey]
+        }
+    }
+}

--- a/Sources/TurnkeySwift/Internal/TurnkeyContext+InternalHelpers.swift
+++ b/Sources/TurnkeySwift/Internal/TurnkeyContext+InternalHelpers.swift
@@ -35,12 +35,14 @@ extension TurnkeyContext {
                 // if we fail that means the selected session expired
                 // so we delete it from the SelectedSessionStore
                 SelectedSessionStore.delete()
+                await MainActor.run { self.authState = .unAuthenticated }
                 return
             }
             
+            await MainActor.run { self.authState = .authenticated }
             _ = try? await setSelectedSession(sessionKey: sessionKey)
         } catch {
-            // Silently fail
+            await MainActor.run { self.authState = .unAuthenticated }
         }
     }
     

--- a/Sources/TurnkeySwift/Internal/TurnkeyContext+InternalHelpers.swift
+++ b/Sources/TurnkeySwift/Internal/TurnkeyContext+InternalHelpers.swift
@@ -24,120 +24,227 @@ extension TurnkeyContext {
     #endif
   }
 
-  /// Attempts to restore the most recently selected session on app launch or resume.
-  ///
-  /// Loads the selected session key from persistent storage and re-establishes the client/user state if valid.
-  func restoreSelectedSession() async {
-    do {
-      guard let sessionKey = try SelectedSessionStore.load(),
-            (try? JwtSessionStore.load(key: sessionKey)) != nil
-      else { return }
-
-      _ = try? await setSelectedSession(sessionKey: sessionKey)
-    } catch {
-      // Silently fail
-    }
-  }
-
-  /// Reschedules expiry timers for all persisted sessions.
-  ///
-  /// Iterates over all stored session keys and schedules timers based on JWT expiration.
-  func rescheduleAllSessionExpiries() async {
-    do {
-      for key in try SessionRegistryStore.all() {
-        guard let dto = try? JwtSessionStore.load(key: key) else { continue }
-        scheduleExpiryTimer(for: key, expTimestamp: dto.exp)
-      }
-    } catch {
-      // Silently fail
-    }
-  }
-
-  /// Sets up a timer that will automatically clear the session when the JWT expires.
-  ///
-  /// - Parameters:
-  ///   - sessionKey: The session key to track.
-  ///   - expTimestamp: The expiration timestamp of the session JWT.
-  func scheduleExpiryTimer(for sessionKey: String, expTimestamp: TimeInterval) {
-    expiryTasks[sessionKey]?.cancel()
-
-    // we add a 5s buffer
-    let delay = expTimestamp - Date().timeIntervalSince1970 - 5
-    guard delay > 0 else {
-      clearSession(for: sessionKey)
-      return
-    }
-
-    expiryTasks[sessionKey] = Task { [weak self] in
-      try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
-      self?.clearSession(for: sessionKey)
-    }
-  }
-
-  /// Fetches the current session user's full profile and associated wallets.
-  ///
-  /// - Parameters:
-  ///   - client: The `TurnkeyClient` instance for API calls.
-  ///   - organizationId: The organization ID associated with the session.
-  ///   - userId: The user ID to retrieve.
-  /// - Returns: A fully populated `SessionUser` object containing user metadata and wallet accounts.
-  func fetchSessionUser(
-    using client: TurnkeyClient,
-    organizationId: String,
-    userId: String
-  ) async throws -> SessionUser {
-    guard !organizationId.isEmpty, !userId.isEmpty else {
-      throw TurnkeySwiftError.invalidResponse
-    }
-
-    do {
-      // run user and wallets requests in parallel
-      async let userResp = client.getUser(organizationId: organizationId, userId: userId)
-      async let walletsResp = client.getWallets(organizationId: organizationId)
-
-      let user = try await userResp.body.json.user
-      let wallets = try await walletsResp.body.json.wallets
-
-      // fetch wallet accounts concurrently
-      let detailed = try await withThrowingTaskGroup(of: SessionUser.UserWallet.self) { group in
-        for w in wallets {
-          group.addTask {
-            let accounts = try await client.getWalletAccounts(
-              organizationId: organizationId,
-              walletId: w.walletId,
-              paginationOptions: nil
-            ).body.json.accounts.map {
-              SessionUser.UserWallet.WalletAccount(
-                id: $0.walletAccountId,
-                curve: $0.curve,
-                pathFormat: $0.pathFormat,
-                path: $0.path,
-                addressFormat: $0.addressFormat,
-                address: $0.address,
-                createdAt: $0.createdAt,
-                updatedAt: $0.updatedAt
-              )
+    /// Attempts to restore the most recently selected session on app launch or resume.
+    ///
+    /// Loads the selected session key from persistent storage and re-establishes the client/user state if valid.
+    func restoreSelectedSession() async {
+        do {
+            guard let sessionKey = try SelectedSessionStore.load(),
+                  (try? JwtSessionStore.load(key: sessionKey)) != nil
+            else {
+                // if we fail that means the selected session expired
+                // so we delete it from the SelectedSessionStore
+                SelectedSessionStore.delete()
+                return
             }
-            return SessionUser.UserWallet(id: w.walletId, name: w.walletName, accounts: accounts)
-          }
+            
+            _ = try? await setSelectedSession(sessionKey: sessionKey)
+        } catch {
+            // Silently fail
+        }
+    }
+    
+    /// Reschedules expiry timers for all persisted sessions.
+    ///
+    /// Iterates over all stored session keys and schedules timers based on JWT expiration.
+    func rescheduleAllSessionExpiries() async {
+        do {
+            for key in try SessionRegistryStore.all() {
+                guard let dto = try? JwtSessionStore.load(key: key) else { continue }
+                scheduleExpiryTimer(for: key, expTimestamp: dto.exp)
+            }
+        } catch {
+            // Silently fail
+        }
+    }
+    
+    /// Schedules an expiry timer to automatically refresh or clear a session when its JWT expires.
+    ///
+    /// - Parameters:
+    ///   - sessionKey: The key identifying the session to monitor.
+    ///   - expTimestamp: The UNIX timestamp (in seconds) when the JWT expires.
+    ///   - buffer: Seconds to subtract from the expiry time to fire early (default is 5 seconds)
+    func scheduleExpiryTimer(
+        for sessionKey: String,
+        expTimestamp: TimeInterval,
+        buffer: TimeInterval = 5
+    ) {
+        expiryTasks[sessionKey]?.cancel()
+        
+        let now     = DispatchTime.now()
+        let interval = max(0, expTimestamp - Date().timeIntervalSince1970 - buffer)
+        let deadline = now + .milliseconds(Int(interval * 1_000))
+        
+        let timer = DispatchSource.makeTimerSource()
+        timer.schedule(deadline: deadline, leeway: .milliseconds(100))
+        timer.setEventHandler { [weak self] in
+            guard let self = self else { return }
+            
+            if let dur = AutoRefreshStore.durationSeconds(for: sessionKey) {
+                Task {
+                    do {
+                        try await self.refreshSession(
+                            expirationSeconds: dur,
+                            sessionKey: sessionKey
+                        )
+                    } catch {
+                        // refreshSession failed so we resort to clearing the session
+                        self.clearSession(for: sessionKey)
+                    }
+                }
+            } else {
+                self.clearSession(for: sessionKey)
+            }
+            timer.cancel()
+        }
+        timer.resume()
+        
+        expiryTasks[sessionKey] = timer
+    }
+    
+    /// Persists all storage-level artefacts for a session, schedules its expiry
+    /// timer, and (optionally) registers the session for auto-refresh.
+    func persistSession(
+        dto: TurnkeySession,
+        sessionKey: String,
+        refreshedSessionTTLSeconds: String? = nil
+    ) throws {
+        try JwtSessionStore.save(dto, key: sessionKey)
+        try SessionRegistryStore.add(sessionKey)
+
+        let priv = try KeyPairStore.getPrivateHex(for: dto.publicKey)
+        if priv.isEmpty { throw TurnkeySwiftError.keyNotFound }
+        try PendingKeysStore.remove(dto.publicKey)
+
+        if let duration = refreshedSessionTTLSeconds {
+            try AutoRefreshStore.set(durationSeconds: duration, for: sessionKey)
+        }
+        
+        scheduleExpiryTimer(for: sessionKey, expTimestamp: dto.exp)
+    }
+
+    /// Removes *only* the stored artefacts for a session (no UI / in-memory reset).
+    ///
+    /// - Parameters:
+    ///   - sessionKey: The key identifying the session in storage.
+    ///   - keepAutoRefresh: Whether to retain any auto-refresh setting.
+    func purgeStoredSession(
+        for sessionKey: String,
+        keepAutoRefresh: Bool
+    ) throws {
+        expiryTasks[sessionKey]?.cancel()
+        expiryTasks.removeValue(forKey: sessionKey)
+
+        if let dto = try? JwtSessionStore.load(key: sessionKey) {
+            try? KeyPairStore.delete(for: dto.publicKey)
         }
 
-        var res: [SessionUser.UserWallet] = []
-        for try await item in group { res.append(item) }
-        return res
-      }
+        JwtSessionStore.delete(key: sessionKey)
+        try? SessionRegistryStore.remove(sessionKey)
 
-      return SessionUser(
-        id: user.userId,
-        userName: user.userName,
-        email: user.userEmail,
-        phoneNumber: user.userPhoneNumber,
-        organizationId: organizationId,
-        wallets: detailed
-      )
-
-    } catch {
-      throw error
+        if !keepAutoRefresh {
+            try? AutoRefreshStore.remove(for: sessionKey)
+        }
     }
-  }
+    
+    /// Updates an existing session with a new JWT, preserving any configured auto-refresh duration.
+    ///
+    /// - Parameters:
+    ///   - jwt: The fresh JWT string returned by the Turnkey backend.
+    ///   - sessionKey: The identifier of the session to update. Defaults to `Constants.Session.defaultSessionKey`.
+    ///   
+    /// - Throws:
+    ///   - `TurnkeySwiftError.keyNotFound` if no session exists under the given key.
+    ///   - `TurnkeySwiftError.failedToCreateSession` if decoding or persistence operations fail.
+    func updateSession(
+        jwt: String,
+        sessionKey: String = Constants.Session.defaultSessionKey
+    ) async throws {
+        do {
+            // eventually we should verify that the jwt was signed by Turnkey
+            // but for now we just assume it is
+
+            guard try JwtSessionStore.load(key: sessionKey) != nil else {
+                throw TurnkeySwiftError.keyNotFound
+            }
+
+            // remove old key material but preserve any auto-refresh duration
+            try purgeStoredSession(for: sessionKey, keepAutoRefresh: true)
+
+            let dto = try JWTDecoder.decode(jwt, as: TurnkeySession.self)
+            let nextDuration = AutoRefreshStore.durationSeconds(for: sessionKey)
+            try persistSession(dto: dto,
+                               sessionKey: sessionKey,
+                               refreshedSessionTTLSeconds: nextDuration)
+        } catch {
+            throw TurnkeySwiftError.failedToCreateSession(underlying: error)
+        }
+    }
+    
+    /// Fetches the current session user's full profile and associated wallets.
+    ///
+    /// - Parameters:
+    ///   - client: The `TurnkeyClient` instance for API calls.
+    ///   - organizationId: The organization ID associated with the session.
+    ///   - userId: The user ID to retrieve.
+    /// - Returns: A fully populated `SessionUser` object containing user metadata and wallet accounts.
+    func fetchSessionUser(
+        using client: TurnkeyClient,
+        organizationId: String,
+        userId: String
+    ) async throws -> SessionUser {
+        guard !organizationId.isEmpty, !userId.isEmpty else {
+            throw TurnkeySwiftError.invalidResponse
+        }
+        
+        do {
+            // run user and wallets requests in parallel
+            async let userResp = client.getUser(organizationId: organizationId, userId: userId)
+            async let walletsResp = client.getWallets(organizationId: organizationId)
+            
+            let user = try await userResp.body.json.user
+            let wallets = try await walletsResp.body.json.wallets
+            
+            // fetch wallet accounts concurrently
+            let detailed = try await withThrowingTaskGroup(of: SessionUser.UserWallet.self) { group in
+                for w in wallets {
+                    group.addTask {
+                        let accounts = try await client.getWalletAccounts(
+                            organizationId: organizationId,
+                            walletId: w.walletId,
+                            paginationOptions: nil
+                        ).body.json.accounts.map {
+                            SessionUser.UserWallet.WalletAccount(
+                                id: $0.walletAccountId,
+                                curve: $0.curve,
+                                pathFormat: $0.pathFormat,
+                                path: $0.path,
+                                addressFormat: $0.addressFormat,
+                                address: $0.address,
+                                createdAt: $0.createdAt,
+                                updatedAt: $0.updatedAt
+                            )
+                        }
+                        return SessionUser.UserWallet(id: w.walletId, name: w.walletName, accounts: accounts)
+                    }
+                }
+                
+                var res: [SessionUser.UserWallet] = []
+                for try await item in group { res.append(item) }
+                return res
+            }
+            
+            return SessionUser(
+                id: user.userId,
+                userName: user.userName,
+                email: user.userEmail,
+                phoneNumber: user.userPhoneNumber,
+                organizationId: organizationId,
+                wallets: detailed
+            )
+            
+        } catch {
+            throw error
+        }
+    }
 }

--- a/Sources/TurnkeySwift/Models/Constants.swift
+++ b/Sources/TurnkeySwift/Models/Constants.swift
@@ -4,6 +4,7 @@ public enum Constants {
 
   public enum Session {
     public static let defaultSessionKey = "com.turnkey.sdk.session"
+    public static let defaultExpirationSeconds = "900"
   }
 
   public enum Storage {
@@ -11,6 +12,7 @@ public enum Constants {
     public static let selectedSessionKey = "com.turnkey.sdk.selectedSession"
     public static let sessionRegistryKey = "com.turnkey.sdk.sessionKeys"
     public static let pendingKeysStoreKey = "com.turnkey.sdk.pendingList"
+    public static let autoRefreshStoreKey = "com.turnkey.sdk.autoRefresh"
   }
 
   public enum Turnkey {

--- a/Sources/TurnkeySwift/Models/Errors.swift
+++ b/Sources/TurnkeySwift/Models/Errors.swift
@@ -20,6 +20,7 @@ enum TurnkeySwiftError: Error {
     case invalidJWT
     case invalidResponse
     case invalidSession
+    case invalidRefreshTTL(String)
     
     case failedToSignPayload(underlying: Error)
     case failedToCreateSession(underlying: Error)

--- a/Sources/TurnkeySwift/Models/Errors.swift
+++ b/Sources/TurnkeySwift/Models/Errors.swift
@@ -12,6 +12,7 @@ enum StorageError: Error {
 enum TurnkeySwiftError: Error {
     case keyGenerationFailed(Error)
     case keyIndexFailed(status: OSStatus)
+    case keyAlreadyExists
     case keyNotFound
     case keychainAddFailed(status: OSStatus)
     case publicKeyMissing
@@ -23,6 +24,7 @@ enum TurnkeySwiftError: Error {
     case failedToSignPayload(underlying: Error)
     case failedToCreateSession(underlying: Error)
     case failedToClearSession(underlying: Error)
+    case failedToRefreshSession(underlying: Error)
     case failedToRefreshUser(underlying: Error)
     case failedToSetSelectedSession(underlying: Error)
     case failedToCreateWallet(underlying: Error)

--- a/Sources/TurnkeySwift/Models/Errors.swift
+++ b/Sources/TurnkeySwift/Models/Errors.swift
@@ -32,6 +32,9 @@ enum TurnkeySwiftError: Error {
     case failedToExportWallet(underlying: Error)
     case failedToImportWallet(underlying: Error)
     case failedToUpdateUser(underlying: Error)
+    case failedToUpdateUserEmail(underlying: Error)
+    case failedToUpdateUserPhoneNumber(underlying: Error)
+
     
     case oauthInvalidURL
     case oauthMissingIDToken

--- a/Sources/TurnkeySwift/Models/SessionModels.swift
+++ b/Sources/TurnkeySwift/Models/SessionModels.swift
@@ -1,5 +1,11 @@
 import Foundation
 
+public enum AuthState{
+    case loading
+    case authenticated
+    case unAuthenticated
+}
+
 public struct TurnkeySession: Codable, Equatable {
   public let exp: TimeInterval
   public let publicKey: String

--- a/Sources/TurnkeySwift/Public/TurnkeyContext+Session.swift
+++ b/Sources/TurnkeySwift/Public/TurnkeyContext+Session.swift
@@ -60,6 +60,7 @@ extension TurnkeyContext {
                 _ = try await setSelectedSession(sessionKey: sessionKey)
             }
             
+            await MainActor.run { self.authState = .authenticated }
         } catch {
             throw TurnkeySwiftError.failedToCreateSession(underlying: error)
         }
@@ -116,10 +117,12 @@ extension TurnkeyContext {
         
         Task { @MainActor in
             if selectedSessionKey == sessionKey {
+                authState = .unAuthenticated
                 selectedSessionKey = nil
-                SelectedSessionStore.delete()
                 client = nil
                 user = nil
+                
+                SelectedSessionStore.delete()
             }
         }
     }

--- a/Sources/TurnkeySwift/Public/TurnkeyContext+User.swift
+++ b/Sources/TurnkeySwift/Public/TurnkeyContext+User.swift
@@ -29,7 +29,7 @@ extension TurnkeyContext {
         }
     }
     
-    /// Updates the currently authenticated user's contact information.
+    /// Updates the contact information for the user associated with the currently selected session.
     ///
     /// - Parameters:
     ///   - email: Optional email address to update.
@@ -61,6 +61,72 @@ extension TurnkeyContext {
             
         } catch {
             throw TurnkeySwiftError.failedToUpdateUser(underlying: error)
+        }
+    }
+    
+    /// Updates the email address for the user associated with the currently selected session.
+    ///
+    /// If a verification token is provided, the email will be marked as verified. Otherwise, it will be considered unverified.
+    /// Passing an empty string ("") will delete the user's email address.
+    ///
+    /// - Parameters:
+    ///   - email: The new email address to update, or an empty string to delete it.
+    ///   - verificationToken: Optional verification token to mark the email as verified.
+    ///
+    /// - Throws: `TurnkeySwiftError.invalidSession` if no session is selected,
+    ///           or `TurnkeySwiftError.failedToUpdateUserEmail` if the update fails.
+    public func updateUserEmail(email: String, verificationToken: String? = nil ) async throws {
+        guard let client, let user else {
+            throw TurnkeySwiftError.invalidSession
+        }
+                
+        do {
+            let resp = try await client.updateUserEmail(
+                organizationId: user.organizationId,
+                userId: user.id,
+                userEmail: email,
+                verificationToken: verificationToken
+            )
+            
+            if try resp.body.json.activity.result.updateUserEmailResult?.userId != nil {
+                await refreshUser()
+            }
+            
+        } catch {
+            throw TurnkeySwiftError.failedToUpdateUserEmail(underlying: error)
+        }
+    }
+    
+    /// Updates the phone number for the user associated with the currently selected session.
+    ///
+    /// If a verification token is provided, the phone number will be marked as verified. Otherwise, it will be considered unverified.
+    /// Passing an empty string ("") will delete the user's phone number.
+    ///
+    /// - Parameters:
+    ///   - phone: The new phone number to update, or an empty string to delete it.
+    ///   - verificationToken: Optional verification token to mark the phone number as verified.
+    ///
+    /// - Throws: `TurnkeySwiftError.invalidSession` if no session is selected,
+    ///           or `TurnkeySwiftError.failedToUpdateUserPhoneNumber` if the update fails.
+    public func updateUserPhoneNumber(phone: String, verificationToken: String? = nil ) async throws {
+        guard let client, let user else {
+            throw TurnkeySwiftError.invalidSession
+        }
+                
+        do {
+            let resp = try await client.updateUserPhoneNumber(
+                organizationId: user.organizationId,
+                userId: user.id,
+                userPhoneNumber: phone,
+                verificationToken: verificationToken
+            )
+            
+            if try resp.body.json.activity.result.updateUserPhoneNumberResult?.userId != nil {
+                await refreshUser()
+            }
+            
+        } catch {
+            throw TurnkeySwiftError.failedToUpdateUserPhoneNumber(underlying: error)
         }
     }
 }

--- a/Sources/TurnkeySwift/Public/TurnkeyContext.swift
+++ b/Sources/TurnkeySwift/Public/TurnkeyContext.swift
@@ -12,7 +12,7 @@ public final class TurnkeyContext: NSObject, ObservableObject {
     @Published public internal(set) var user: SessionUser?
     
     // internal state
-    internal var expiryTasks: [String: Task<Void, Never>] = [:]
+    internal var expiryTasks: [String: DispatchSourceTimer] = [:]
     internal let apiUrl: String
     
     // configurable base URL
@@ -42,7 +42,7 @@ public final class TurnkeyContext: NSObject, ObservableObject {
         // clean up expired sessions and pending keys
         PendingKeysStore.purge()
         SessionRegistryStore.purgeExpiredSessions()
-        
+                
         // restore session and timers after launch
         Task { [weak self] in
             await self?.rescheduleAllSessionExpiries()

--- a/Sources/TurnkeySwift/Public/TurnkeyContext.swift
+++ b/Sources/TurnkeySwift/Public/TurnkeyContext.swift
@@ -41,8 +41,9 @@ public final class TurnkeyContext: NSObject, ObservableObject {
     
     private func postInitSetup() {
         // clean up expired sessions and pending keys
-        PendingKeysStore.purge()
         SessionRegistryStore.purgeExpiredSessions()
+        PendingKeysStore.purge()
+
                 
         // restore session and timers after launch
         Task { [weak self] in

--- a/Sources/TurnkeySwift/Public/TurnkeyContext.swift
+++ b/Sources/TurnkeySwift/Public/TurnkeyContext.swift
@@ -7,6 +7,7 @@ import TurnkeyHttp
 public final class TurnkeyContext: NSObject, ObservableObject {
     
     // public state
+    @Published public internal(set) var authState: AuthState = .loading
     @Published public internal(set) var client: TurnkeyClient?
     @Published public internal(set) var selectedSessionKey: String?
     @Published public internal(set) var user: SessionUser?


### PR DESCRIPTION
- Add synchronous `AuthState` 
- Added `refreshSession` 
- Added `updateUserEmail` and `updateUserPhoneNumber` for updating email/phone numbers with the ability to keep them verified
- Added support for automatically refreshing the session before it expires if the app is open, by passing an optional `refreshedSessionTTLSeconds` parameter to createSession. This value defines how long each refreshed session should last.
- Fixed a scheduling issue where expiry timers were not firing correctly while the app was active in the foreground.
- Synced to v2025.6.13

