### PR TITLE
chore: rename package from swift-sdk to TurnkeySDK

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# swift-sdk
+# TurnkeySDK
 
 ## Getting Started
 

--- a/Package.swift
+++ b/Package.swift
@@ -2,7 +2,7 @@
 import PackageDescription
 
 let package = Package(
-    name: "swift-sdk",
+    name: "TurnkeySDK",
     platforms: [.macOS(.v14), .iOS(.v17), .tvOS(.v16), .watchOS(.v9), .visionOS(.v1)],
     products: [
         .library(name: "TurnkeyEncoding", targets: ["TurnkeyEncoding"]),


### PR DESCRIPTION
Changed the `name` field in `Package.swift` from `swift-sdk` to `TurnkeySDK`

Closes this [Linear ticket](https://linear.app/turnkey/issue/ENG-3897/rename-swift-sdk-package-name-from-swift-sdk-to-turnkeysdk)